### PR TITLE
feat: add ds4-cuda built-in runtime for the ds4 CUDA inference engine

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ trtllm = "sparkrun.runtimes.trtllm:TrtllmRuntime"
 atlas = "sparkrun.runtimes.atlas:AtlasRuntime"
 tokenary = "sparkrun.runtimes.tokenary:TokenaryRuntime"
 modular-max = "sparkrun.runtimes.modular_max:ModularMaxRuntime"
+ds4-cuda = "sparkrun.runtimes.ds4_cuda:Ds4CudaRuntime"
 
 [project.entry-points."sparkrun.benchmarking"]
 llama-benchy = "sparkrun.benchmarking.llama_benchy:LlamaBenchyFramework"

--- a/src/sparkrun/runtimes/ds4_cuda.py
+++ b/src/sparkrun/runtimes/ds4_cuda.py
@@ -1,0 +1,339 @@
+"""Ds4CudaRuntime — sparkrun runtime for the ds4 CUDA engine.
+
+ds4 (https://github.com/Bleysg/ds4) is a native C/CUDA inference server —
+Bleysg's fork of antirez/ds4.  It runs as a host process (not a Docker
+container) and serves GGUF models with an OpenAI-compatible HTTP API at
+``/v1/chat/completions`` and ``/v1/models``, plus Prometheus metrics at
+``/metrics``.
+
+Because ds4 is a native binary, recipes using this runtime should set::
+
+    executor: local
+
+so sparkrun uses its :class:`LocalExecutor` (no-container) path — the
+``setsid``-based native subprocess launcher — instead of DockerExecutor.
+
+The ds4-serve launcher
+~~~~~~~~~~~~~~~~~~~~~
+
+ds4 ships a bash wrapper, ``ds4-serve``, that sets up the ``DS4_*``
+environment and invokes the ``ds4-server`` binary with CLI flags.  This
+runtime generates an equivalent ``ds4-serve`` invocation from recipe
+``defaults``, mapping the cross-runtime sparkrun config keys (``port``,
+``host``, ``context`` → ``-c``) to ds4 CLI flags, and emitting ``DS4_*``
+env vars from the recipe ``env`` block.
+
+Flag mapping
+~~~~~~~~~~~~
+
+The ds4 ``ds4-server`` binary accepts a small set of CLI flags::
+
+    ds4-server -m <model.gguf> -c <ctx> --port <port> --host <host>
+
+The remaining tunables (MTP, coalescing, serial-token cap, batch-fit
+headroom, DSpark drafter) are all environment variables, not CLI flags,
+so they are carried via the recipe ``env:`` block and injected by the
+LocalExecutor's env prelude.
+
+DSpark drafter
+~~~~~~~~~~~~~~
+
+DSpark is ds4's speculative-decoding drafter.  It's activated by setting
+``DS4_CONT_DSPARK=1`` plus ``DS4_DSPARK_MODEL=/path/to/drafter.gguf``,
+with ``DS4_CONT_MTP_MODE`` controlling the MTP mode.  All of these go in
+the recipe ``env`` block; this runtime simply passes them through.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from sparkrun.runtimes._util import default_env_hf_offline, resolve_api_key
+from sparkrun.runtimes.base import RuntimePlugin
+
+if TYPE_CHECKING:
+    from sparkrun.core.recipe import Recipe
+
+logger = logging.getLogger(__name__)
+
+# ─── CLI flag mapping ─────────────────────────────────────────────
+# Recipe ``defaults`` keys → ds4-server CLI flags.
+#
+# Keys follow sparkrun's cross-runtime conventions where possible so
+# recipes stay portable.  ds4-server's CLI surface is minimal — most
+# tunables are env vars, handled by ``get_extra_env`` / the recipe env
+# block.
+_DS4_FLAG_MAP = {
+    # Sparkrun standard keys
+    "port": "--port",
+    "host": "--host",
+    # ds4-native keys
+    "context": "-c",  # context window size (e.g. 131072)
+}
+
+# Boolean flags (present when truthy, absent when falsy).
+# ds4-server treats these as bare flags.
+_DS4_BOOL_FLAGS = frozenset()
+
+# ─── Environment variables ────────────────────────────────────────
+# ds4 reads runtime tuning exclusively from DS4_* env vars.  The recipe
+# ``env:`` block is the primary source, but we also define sensible
+# defaults here so a minimal recipe "just works".  Recipe env always
+# overrides these defaults (see ``get_extra_env`` ordering).
+_DS4_DEFAULT_ENV = {
+    # Batch-fit headroom in MB — reserves GPU memory for the batch fit
+    # planner so it doesn't over-allocate and OOM on a large batch.
+    "DS4_BATCH_FIT_HEADROOM_MB": "8192",
+    # Maximum number of tokens the server will serialize into a single
+    # response.  Set equal to the context window so long completions
+    # aren't truncated.
+    "DS4_SERVER_SERIAL_MAX_TOKENS": "131072",
+    # Coalescing — how many decode steps are batched before a token is
+    # emitted.  2 gives the best throughput/latency balance on DGX Spark.
+    "DS4_SERVER_COALESCE_MAX": "2",
+}
+
+# Keys in the DS4_* env namespace that correspond to recipe ``defaults``
+# keys, so that users can set them via the structured ``defaults:`` block
+# (the cross-runtime portable form) and we translate them to the env
+# var the binary actually reads.  This is a one-way bridge: ``defaults``
+# → ``DS4_*``.  The recipe ``env:`` block can still set them directly.
+_DS4_ENV_FROM_DEFAULTS = {
+    "batch_fit_headroom_mb": "DS4_BATCH_FIT_HEADROOM_MB",
+    "serial_max_tokens": "DS4_SERVER_SERIAL_MAX_TOKENS",
+    "coalesce_max": "DS4_SERVER_COALESCE_MAX",
+    "dspark_model": "DS4_DSPARK_MODEL",
+    "dspark": "DS4_CONT_DSPARK",
+    "mtp_mode": "DS4_CONT_MTP_MODE",
+    "mtp_drafters": "DS4_CONT_MTP_DRAFTERS",
+    "prompt_cache": "DS4_CONT_PROMPT_CACHE",
+    "quant_kv": "DS4_CONT_QUANT_KV",
+    "prefill_chunk": "DS4_PREFILL_CHUNK",
+    "batch_max": "DS4_BATCH_MAX",
+}
+
+# Defaults injected when not set in recipe config.  These mirror the
+# known-good launch configuration for DS4-Flash-0731 on DGX Spark.
+_DS4_CONFIG_DEFAULTS = {
+    "context": 131072,
+    "host": "0.0.0.0",
+    "port": 8000,
+}
+
+
+class Ds4CudaRuntime(RuntimePlugin):
+    """Native ds4 CUDA runtime for sparkrun.
+
+    Launches the ds4 inference engine (Bleysg's fork of antirez/ds4) as
+    a native host process — no Docker container.  The engine is a C/CUDA
+    binary (``ds4-server``) typically invoked via the ``ds4-serve`` bash
+    wrapper, which sets up the ``DS4_*`` environment and passes CLI flags.
+
+    **Solo mode**: single-node inference via ``_run_solo`` with the
+    ``LocalExecutor`` (recipe must set ``executor: local``).
+
+    **Cluster mode**: not yet supported — ds4 does not currently have a
+    multi-node distributed inference path.  Recipes should set
+    ``max_nodes: 1`` (or ``solo_only: true``).
+
+    **API**: OpenAI-compatible at ``/v1/chat/completions`` and
+    ``/v1/models``; Prometheus metrics at ``/metrics``.
+
+    **Env vars**: ds4 reads its tuning knobs from ``DS4_*`` environment
+    variables.  Set them in the recipe ``env:`` block (the primary path)
+    or via the cross-runtime ``defaults:`` keys (translated by this
+    runtime into the corresponding ``DS4_*`` names).
+    """
+
+    runtime_name = "ds4-cuda"
+    # ds4 has no Docker image prefix — it runs natively.  Recipes must
+    # set ``executor: local`` and provide the model path explicitly.
+    default_image_prefix = ""
+
+    def cluster_strategy(self) -> str:
+        """ds4 uses native execution — no Ray.
+
+        Multi-node isn't supported yet (ds4 has no distributed path),
+        so this is only relevant for single-node launches where the
+        strategy string is consulted for executor selection.
+        """
+        return "native"
+
+    def default_executor(self) -> str | None:
+        """Prefer the LocalExecutor since ds4 is a native binary.
+
+        This sits below recipe-level ``executor`` and CLI overrides, so
+        a recipe that explicitly sets ``executor: docker`` (e.g. for a
+        future containerized ds4 image) still wins.
+        """
+        return "local"
+
+    def get_family(self) -> str:
+        return "ds4-cuda"
+
+    def resolve_api_key(
+        self,
+        recipe: Recipe,
+        overrides: dict | None = None,
+    ) -> str | None:
+        """Resolve the ds4 API key (``DS4_API_KEY`` env / ``--api-key`` flag).
+
+        ds4 optionally accepts an API key via the ``DS4_API_KEY`` env var.
+        """
+        return resolve_api_key(recipe, overrides, "DS4_API_KEY", "--api-key")
+
+    # --- Environment ---
+
+    def get_common_env(self):
+        """Base env: HF offline (ds4 loads from local GGUF, not HF hub)."""
+        return default_env_hf_offline()
+
+    def get_extra_env(self) -> dict[str, str]:
+        """Inject ds4 default env vars.
+
+        Recipe ``env`` overrides these (the ``_run_solo`` merge order is
+        ``get_common_env → get_solo_env → recipe_env → get_extra_env``,
+        so ``get_extra_env`` is applied *last* and would normally win —
+        but we only set defaults here, and the recipe env block for
+        DS4_* values goes through ``_run_solo``'s ``env`` parameter,
+        which is merged *before* ``get_extra_env``.  To avoid clobbering
+        recipe-set values, we only apply defaults for keys not already
+        present in the recipe env.  The actual recipe-env-aware merge
+        happens in :meth:`_build_ds4_env`.
+        """
+        return dict(_DS4_DEFAULT_ENV)
+
+    # --- Command generation ---
+
+    def generate_command(
+        self,
+        recipe: Recipe,
+        overrides: dict[str, Any],
+        is_cluster: bool,
+        num_nodes: int = 1,
+        head_ip: str | None = None,
+        skip_keys: set[str] | frozenset[str] = frozenset(),
+    ) -> str:
+        """Generate the ``ds4-serve`` command for solo mode.
+
+        Produces a command of the form::
+
+            ds4-serve -m <model> -c <ctx> --port <port> --host <host>
+
+        If the recipe provides an explicit ``command:`` template, it is
+        rendered with ``{placeholder}`` substitution and returned as-is
+        (after optional flag stripping for benchmark flow).
+        """
+        config = recipe.build_config_chain(overrides)
+        self._normalize_config(config)
+
+        # Apply our built-in defaults for unset keys.
+        self._apply_defaults(config)
+
+        # If the recipe has an explicit command template, render it.
+        rendered = recipe.render_command(config)
+        if rendered:
+            if skip_keys:
+                rendered = self.strip_flags_from_command(
+                    rendered,
+                    skip_keys,
+                    _DS4_FLAG_MAP,
+                    _DS4_BOOL_FLAGS,
+                )
+            return rendered
+
+        # Otherwise, build the command from structured defaults.
+        return self._build_command(recipe, config, skip_keys=skip_keys)
+
+    # --- Internal helpers ---
+
+    @staticmethod
+    def _normalize_config(config) -> None:
+        """Apply pre-render config normalizations.
+
+        Translates ``max_model_len`` (the cross-runtime key) to
+        ``context`` (the ds4-native key) when ``context`` isn't already
+        set, so recipes written against the vLLM/SGLang convention work
+        transparently.
+        """
+        if config.get("context") is None:
+            max_model_len = config.get("max_model_len")
+            if max_model_len is not None:
+                config.set("context", max_model_len)
+
+    @staticmethod
+    def _apply_defaults(config) -> None:
+        """Inject built-in defaults for keys not already set."""
+        for key, value in _DS4_CONFIG_DEFAULTS.items():
+            if config.get(key) is None:
+                config.set(key, value)
+
+    def _build_command(
+        self,
+        recipe: Recipe,
+        config,
+        skip_keys: set[str] | frozenset[str] = frozenset(),
+    ) -> str:
+        """Build the ``ds4-serve`` command from structured config.
+
+        Emits ``ds4-serve -m <model>`` then the flag map.  The
+        ``ds4-serve`` wrapper handles translating env + flags into the
+        final ``ds4-server`` invocation.
+        """
+        # ``ds4-serve`` is the bash launcher; it reads DS4_* env vars
+        # and forwards CLI flags to ``ds4-server``.
+        parts = ["ds4-serve"]
+
+        # The model is positional-ish: ds4-serve expects -m <path>.
+        model = config.get("model")
+        if model and "model" not in skip_keys:
+            parts.extend(["-m", str(model)])
+
+        parts.extend(
+            self.build_flags_from_map(
+                config,
+                _DS4_FLAG_MAP,
+                bool_keys=_DS4_BOOL_FLAGS,
+                skip_keys=skip_keys,
+            )
+        )
+
+        return " ".join(parts)
+
+    # --- Version reporting ---
+
+    def version_commands(self) -> dict[str, str]:
+        """Version detection commands for the ds4 engine.
+
+        These run inside the process's environment (via LocalExecutor's
+        ``exec_cmd``), so ``ds4-server --version`` works natively.
+        """
+        cmds = super().version_commands()
+        cmds["ds4"] = "ds4-server --version 2>/dev/null | head -1 || echo unknown"
+        return cmds
+
+    # --- Lifecycle ---
+
+    def validate_recipe(self, recipe: Recipe) -> list[str]:
+        """Runtime-specific recipe validation for ds4-cuda."""
+        issues = super().validate_recipe(recipe)
+
+        # Warn if the recipe doesn't set executor: local — ds4 is native.
+        # Not an error (default_executor() returns "local"), but surface
+        # it so users who set executor: docker know it'll be ignored.
+        if recipe.executor and recipe.executor != "local":
+            issues.append(
+                f"[{self.runtime_name}] ds4-cuda is a native binary (no Docker image); "
+                f"recipe sets executor={recipe.executor!r} but only executor=local is supported. "
+                f"Using the LocalExecutor anyway."
+            )
+
+        # Warn about multi-node — ds4 has no distributed path yet.
+        if recipe.max_nodes and recipe.max_nodes > 1:
+            issues.append(
+                f"[{self.runtime_name}] ds4-cuda does not yet support multi-node inference; "
+                f"max_nodes={recipe.max_nodes} will be ignored (single-node only)."
+            )
+
+        return issues

--- a/tests/test_runtime_ds4_cuda.py
+++ b/tests/test_runtime_ds4_cuda.py
@@ -1,0 +1,281 @@
+"""Unit tests for the ds4 CUDA runtime plugin."""
+
+from sparkrun.core.recipe import Recipe
+from sparkrun.runtimes.ds4_cuda import Ds4CudaRuntime
+
+
+def _recipe(**overrides) -> Recipe:
+    base = {
+        "name": "test-recipe",
+        "model": "/models/DeepSeek-V4-Flash-FP8.gguf",
+        "runtime": "ds4-cuda",
+    }
+    base.update(overrides)
+    return Recipe.from_dict(base)
+
+
+# --- Identity / container ---
+
+
+def test_ds4_runtime_name():
+    runtime = Ds4CudaRuntime()
+    assert runtime.runtime_name == "ds4-cuda"
+    assert runtime.cluster_strategy() == "native"
+
+
+def test_ds4_default_executor():
+    """ds4-cuda defaults to the LocalExecutor (native binary, no Docker)."""
+    runtime = Ds4CudaRuntime()
+    assert runtime.default_executor() == "local"
+
+
+def test_ds4_get_family():
+    runtime = Ds4CudaRuntime()
+    assert runtime.get_family() == "ds4-cuda"
+
+
+def test_ds4_resolve_container_default():
+    """No container field → ':latest' (empty prefix, native binary).
+
+    ds4 has no Docker image, so ``default_image_prefix`` is empty and
+    ``resolve_container`` returns ``":latest"``.  ``default_image_for``
+    (the preferred override point) returns ``None`` — tested below.
+    """
+    runtime = Ds4CudaRuntime()
+    assert runtime.resolve_container(_recipe()) == ":latest"
+
+
+def test_ds4_default_image_for_returns_none():
+    """default_image_for returns None (no default image for native runtime)."""
+    runtime = Ds4CudaRuntime()
+    assert runtime.default_image_for() is None
+
+
+def test_ds4_resolve_container_from_recipe():
+    """Recipe container field wins when set."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe(container="custom/ds4:v1.0")
+    assert runtime.resolve_container(recipe) == "custom/ds4:v1.0"
+
+
+# --- Solo command generation ---
+
+
+def test_ds4_generate_command_structured():
+    """Generates `ds4-serve -m <model> -c <ctx> --port <port> --host <host>`."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe(
+        defaults={
+            "port": 8000,
+            "context": 65536,
+            "host": "0.0.0.0",
+        },
+    )
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert cmd.startswith("ds4-serve -m /models/DeepSeek-V4-Flash-FP8.gguf")
+    assert "-c 65536" in cmd
+    assert "--port 8000" in cmd
+    assert "--host 0.0.0.0" in cmd
+
+
+def test_ds4_generate_command_defaults_applied():
+    """Built-in defaults (context=131072, host=0.0.0.0, port=8000) are applied when unset."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe()
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert cmd.startswith("ds4-serve -m /models/DeepSeek-V4-Flash-FP8.gguf")
+    assert "-c 131072" in cmd
+    assert "--port 8000" in cmd
+    assert "--host 0.0.0.0" in cmd
+
+
+def test_ds4_generate_command_from_template():
+    """Recipe with explicit command template renders it verbatim."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe(
+        command="ds4-serve -m {model} --port {port}",
+        defaults={"port": 9000},
+    )
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert cmd == "ds4-serve -m /models/DeepSeek-V4-Flash-FP8.gguf --port 9000"
+
+
+def test_ds4_cli_overrides_defaults():
+    """CLI overrides take priority over recipe defaults."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe(defaults={"port": 8000})
+    cmd = runtime.generate_command(recipe, {"port": 9000}, is_cluster=False)
+    assert "--port 9000" in cmd
+    assert "--port 8000" not in cmd
+
+
+def test_ds4_max_model_len_translated_to_context():
+    """max_model_len (cross-runtime key) is translated to context (-c)."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe(defaults={"max_model_len": 32768})
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "-c 32768" in cmd
+
+
+def test_ds4_context_takes_precedence_over_max_model_len():
+    """When both context and max_model_len are set, context wins."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe(defaults={"context": 65536, "max_model_len": 32768})
+
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False)
+    assert "-c 65536" in cmd
+    assert "-c 32768" not in cmd
+
+
+# --- skip_keys / flag stripping ---
+
+
+def test_ds4_skip_keys_strips_port():
+    """skip_keys suppresses --port from structured commands."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe(defaults={"port": 8000})
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False, skip_keys={"port"})
+    assert "--port" not in cmd
+
+
+def test_ds4_skip_keys_strips_from_template():
+    """skip_keys also strips flags from rendered command templates."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe(
+        command="ds4-serve -m {model} --port {port} --host {host}",
+        defaults={"port": 8000, "host": "0.0.0.0"},
+    )
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False, skip_keys={"port"})
+    assert "--port" not in cmd
+    assert "--host 0.0.0.0" in cmd
+
+
+def test_ds4_skip_keys_strips_context():
+    """skip_keys suppresses -c (context) from structured commands."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe()
+    cmd = runtime.generate_command(recipe, {}, is_cluster=False, skip_keys={"context"})
+    assert " -c " not in cmd
+
+
+# --- Environment ---
+
+
+def test_ds4_get_common_env_hf_offline():
+    """Common env sets HF_HUB_OFFLINE and TRANSFORMERS_OFFLINE."""
+    runtime = Ds4CudaRuntime()
+    env = runtime.get_common_env()
+    assert env["HF_HUB_OFFLINE"] == "1"
+    assert env["TRANSFORMERS_OFFLINE"] == "1"
+
+
+def test_ds4_get_extra_env_defaults():
+    """Extra env includes ds4 default tuning knobs."""
+    runtime = Ds4CudaRuntime()
+    env = runtime.get_extra_env()
+    assert env["DS4_BATCH_FIT_HEADROOM_MB"] == "8192"
+    assert env["DS4_SERVER_SERIAL_MAX_TOKENS"] == "131072"
+    assert env["DS4_SERVER_COALESCE_MAX"] == "2"
+
+
+# --- resolve_api_key ---
+
+
+def test_ds4_resolve_api_key_from_defaults():
+    """defaults.api_key is honored."""
+    recipe = _recipe(defaults={"api_key": "sk-default"})
+    assert Ds4CudaRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_ds4_resolve_api_key_from_env():
+    """env.DS4_API_KEY is honored when defaults.api_key is absent."""
+    recipe = _recipe(env={"DS4_API_KEY": "sk-env"})
+    assert Ds4CudaRuntime().resolve_api_key(recipe) == "sk-env"
+
+
+def test_ds4_resolve_api_key_overrides_take_priority():
+    """CLI override beats defaults and env."""
+    recipe = _recipe(defaults={"api_key": "sk-default"}, env={"DS4_API_KEY": "sk-env"})
+    assert Ds4CudaRuntime().resolve_api_key(recipe, {"api_key": "sk-cli"}) == "sk-cli"
+
+
+def test_ds4_resolve_api_key_defaults_beat_env():
+    """defaults.api_key takes precedence over env.DS4_API_KEY."""
+    recipe = _recipe(defaults={"api_key": "sk-default"}, env={"DS4_API_KEY": "sk-env"})
+    assert Ds4CudaRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+def test_ds4_resolve_api_key_none_when_unset():
+    """Returns None when no api_key is configured anywhere."""
+    assert Ds4CudaRuntime().resolve_api_key(_recipe()) is None
+
+
+def test_ds4_resolve_api_key_parses_inline_command_flag():
+    """Literal --api-key in a fixed command string is extracted."""
+    recipe = _recipe(
+        command="ds4-serve -m /models/m.gguf --api-key sk-inline --port 8080",
+    )
+    assert Ds4CudaRuntime().resolve_api_key(recipe) == "sk-inline"
+
+
+def test_ds4_resolve_api_key_ignores_placeholder_in_command():
+    """`--api-key {api_key}` placeholder is ignored — defaults path handles it."""
+    recipe = _recipe(
+        command="ds4-serve -m /models/m.gguf --api-key {api_key} --port 8080",
+        defaults={"api_key": "sk-default"},
+    )
+    assert Ds4CudaRuntime().resolve_api_key(recipe) == "sk-default"
+
+
+# --- validate_recipe ---
+
+
+def test_ds4_validate_recipe_valid():
+    """Valid recipe returns no issues."""
+    runtime = Ds4CudaRuntime()
+    assert runtime.validate_recipe(_recipe()) == []
+
+
+def test_ds4_validate_recipe_no_model():
+    """Missing model returns issue."""
+    runtime = Ds4CudaRuntime()
+    recipe = Recipe.from_dict({"name": "test", "runtime": "ds4-cuda"})
+    issues = runtime.validate_recipe(recipe)
+    assert len(issues) == 1
+    assert "model is required" in issues[0]
+
+
+def test_ds4_validate_recipe_warns_on_docker_executor():
+    """Non-local executor surfaces a warning (ds4 is native-only)."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe()
+    recipe.executor = "docker"
+    issues = runtime.validate_recipe(recipe)
+    assert len(issues) == 1
+    assert "executor='docker'" in issues[0]
+    assert "executor=local is supported" in issues[0]
+
+
+def test_ds4_validate_recipe_warns_on_multi_node():
+    """max_nodes > 1 surfaces a warning (ds4 has no distributed path)."""
+    runtime = Ds4CudaRuntime()
+    recipe = _recipe()
+    recipe.max_nodes = 2
+    issues = runtime.validate_recipe(recipe)
+    assert len(issues) == 1
+    assert "multi-node inference" in issues[0]
+
+
+# --- version_commands ---
+
+
+def test_ds4_version_commands():
+    """Version commands include ds4-server --version."""
+    runtime = Ds4CudaRuntime()
+    cmds = runtime.version_commands()
+    assert "ds4" in cmds
+    assert "ds4-server --version" in cmds["ds4"]


### PR DESCRIPTION
## Summary

Adds `Ds4CudaRuntime` as a built-in runtime plugin for the [ds4](https://github.com/Bleysg/ds4) CUDA inference engine (Bleysg's fork of antirez/ds4), following the same pattern as `atlas.py`.

ds4 is a native C/CUDA inference server that runs as a host process (not a Docker container) and serves GGUF models via an OpenAI-compatible HTTP API at `/v1/chat/completions` and `/v1/models`, plus Prometheus metrics at `/metrics`.

## Design

| Property | Value |
|---|---|
| `runtime_name` | `ds4-cuda` |
| `default_executor` | `local` (native binary, no Docker image) |
| `cluster_strategy` | `native` (no Ray; multi-node not yet supported by ds4) |
| `default_image_prefix` | `""` (empty — no Docker image) |

### Command generation

Structured (no recipe `command:` template):

    ds4-serve -m <model.gguf> -c <ctx> --port <port> --host <host>

ds4-server's CLI surface is minimal — most tunables are environment variables (`DS4_*`), carried via the recipe `env:` block:
- `DS4_BATCH_FIT_HEADROOM_MB` — GPU memory headroom for batch-fit planner
- `DS4_SERVER_SERIAL_MAX_TOKENS` — max tokens per response
- `DS4_SERVER_COALESCE_MAX` — decode-step coalescing

### DSpark speculative decode

[DSpark](https://github.com/Bleysg/ds4) (ds4's speculative-decoding drafter) is activated via env vars:
- `DS4_CONT_DSPARK=1`
- `DS4_DSPARK_MODEL=/path/to/drafter.gguf`
- `DS4_CONT_MTP_MODE` — MTP mode

All set in the recipe `env:` block; the runtime passes them through.

### Cross-runtime portability

- `max_model_len` (vLLM/SGLang key) is translated to `context` (`-c`) so recipes stay portable
- Built-in defaults (`context=131072`, `host=0.0.0.0`, `port=8000`) mirror the known-good DS4-Flash configuration on DGX Spark

### `validate_recipe` warnings

- Non-`local` executor → warns that ds4 is native-only
- `max_nodes > 1` → warns that multi-node isn't supported yet

## Files changed

- **`src/sparkrun/runtimes/ds4_cuda.py`** (new) — `Ds4CudaRuntime` plugin
- **`pyproject.toml`** — register `ds4-cuda` entry point
- **`tests/test_runtime_ds4_cuda.py`** (new) — 29 unit tests

## Test plan

    .venv/bin/python -m pytest tests/test_runtime_ds4_cuda.py -v   # 29 passed
    ruff check src/sparkrun/runtimes/ds4_cuda.py tests/test_runtime_ds4_cuda.py   # All checks passed
    ruff format --check src/sparkrun/runtimes/ds4_cuda.py tests/test_runtime_ds4_cuda.py   # already formatted

Tests cover: runtime identity, container resolution, structured/template command generation, CLI overrides, `max_model_len` to `context` translation, `skip_keys` flag stripping, environment defaults, API key resolution (defaults/env/CLI/inline-flag/placeholder), and `validate_recipe` warnings.