### PR TITLE
Feature/coldsnap host seams

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1963,6 +1963,53 @@ user has. `SUBPATH_FIELDS` is the list any new path-forming field must join, or 
 lists registries, `@registry/` lists recipes from that registry. Falls back to showing registry names when recipe cache
 isn't populated.
 
+### Plugin-Declared Registries (`core/registry_defaults.py`)
+
+`BOOTSTRAP_REGISTRY_URLS` / `FALLBACK_DEFAULT_REGISTRIES` are closed constants. `register_default_registry(entry,
+owner=…)` is the extension point beside them, for a plugin whose recipes are **inert without it** — its registry
+resolves (`@coldsnap/<recipe>`) for anyone with the plugin enabled, with nothing to `registry add`. In-process (the
+`platforms` / `register_kv_strategy` precedent), re-exported from `sparkrun.plugins`, called from `register(v)`.
+Author-facing docs: `docs/PLUGINS.md`; full rationale: `.slop/plugin-declared-registries-design.md`.
+
+Six properties are load-bearing:
+
+- **Registration does no I/O.** `init_sparkrun` runs on *every* shell completion (Click resolves the command tree
+  through `PluggableGroup.get_command`; measured ~30 ms stock against a 92 ms unavoidable `import sparkrun.cli`), so
+  anything expensive lands on the interactive path. This is also why a plugin cannot source its *names* from a remote
+  `.sparkrun/registry.yaml` — the overlay must be computable offline. Declare in code; the repo manifest stays for
+  users adding the registry by URL.
+- **An overlay, never persisted.** `_apply_plugin_overlay` runs **last** in `_load_registries` / `_default_registries`,
+  after every convergent rewrite and any save, so declared entries never reach the migration or persistence path.
+  `_save_registries` additionally skips anything with `declared_by` set — every mutating command reads through
+  `_load_registries` and rewrites the whole document, so without that filter the first `registry disable` of anything
+  would quietly persist every declared registry and they would outlive their plugin. Uninstalling is therefore free:
+  declaration gone, entry gone, nothing to reap.
+- **Materialize on mutation.** `enable`/`disable`/`trust`/`untrust` call `_materialize_declared`, which *clears*
+  `declared_by` — that is what lets the entry through `_save_registries`, and from then on the file wins. `remove`
+  writes a **tombstone** (`suppressed_plugin_registries`) instead of deleting, because there is nothing in
+  `registries.yaml` to delete and dropping it in memory would let the declaration restore it next launch — a removal
+  that silently fails to remove. `add_registry` clears the tombstone.
+- **Trust is tiered by provenance, and the tier comes from the loader.** In-tree may ship `trusted=True` (same review
+  and release gate as the shipped defaults; for a vendored plugin, a pinned commit with per-file digests); out-of-tree
+  is forced `False` — installing a plugin says "I want this capability", not "I grant its recipe repo standing
+  hook-execution rights over whatever it contains next month". `load_plugin_module(…, tier=…)` sets a **contextvar**
+  around the load rather than taking an argument, because the *plugin* makes the registration call; the default is
+  `OUT_OF_TREE` (least privilege), so a declaration made outside any loader cannot acquire in-tree trust.
+- **Collisions are refused and warned, not ranked.** A declaration colliding with a shipped default is rejected with a
+  warning naming the owner — checked **before** the file-entry rule, since a shipped default is normally present in the
+  file and the reverse order would silently ignore a plugin trying to redefine `official`. Ranking would permit a
+  namespace redirect that `validate_registry_name` cannot catch (it only guards *reserved* names). The user's own file
+  entry is the one true override.
+- **Validation raises at the declaration's call site** (`validate_registry_name` + `assert_safe_registry_entry`) rather
+  than dropping the entry where the overlay is applied: a plugin is local code we can fix, unlike a hostile remote
+  manifest that must be survived. Note `validate_registry_name` checks the **registry URL's** org, not the plugin
+  repo's — `EXTERNAL_RESERVED_NAMES` reserves `coldsnap` / `coldsnap-vanilla` to `sparksq`. Reservation stays in core
+  so a plugin cannot reserve its own namespace.
+
+Telemetry counts declared registries as `plugin_registry_count` and excludes them from `non_default_*` — a first-party
+plugin contributing its own registry is not "the user added a third party", and counting it as such would silently
+change a metric already in published series.
+
 ### Recipe Catalog ("what recipes exist?")
 
 All recipe *enumeration* flows through one function, **`api.search_recipes(query, …) -> list[RecipeSummary]`**

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -140,3 +140,71 @@ plugins:
 `plugins.paths` stays reserved for discovery. Everything else under `plugins`
 is a plugin's own namespace, so a plugin never needs a bespoke top-level config
 block or a property on `SparkrunConfig`.
+
+## Contributing a recipe registry
+
+A plugin whose recipes are inert without it can declare the registry that holds
+them, so `@<registry>/<recipe>` resolves for anyone with the plugin enabled and
+nobody has to `sparkrun registry add` anything:
+
+```python
+from sparkrun.plugins import RegistryEntry, register_default_registry
+
+
+def register(v):
+    register_default_registry(
+        RegistryEntry(
+            name="coldsnap",
+            url="https://github.com/sparksq/sparkrun-recipes.git",
+            subpath="coldsnap-recipes",
+            description="Qualified ColdSnap recipes",
+            visible=False,       # stays out of `sparkrun list`; @coldsnap/… still resolves
+        ),
+        owner="coldsnap",
+    )
+```
+
+Call it once per registry. `enabled` and `visible` are honored, so a control or
+opt-in lane can ship disabled.
+
+**Declarations are an overlay, not a config edit.** They are merged into the
+list `RegistryManager` loads and are never written to `registries.yaml`, so
+disabling or uninstalling the plugin takes its registries with it and leaves
+nothing to clean up. The user's own file always wins on a name collision, which
+is how they repoint a declared registry at an internal mirror.
+
+User decisions still stick. `registry disable` / `trust` / `untrust` on a
+declared registry **materializes** it — writes it into `registries.yaml` as an
+ordinary entry the user now owns — and `registry remove` records a tombstone so
+the declaration cannot put it back on the next launch. `sparkrun registry list`
+grows a `Source` column showing `plugin:<owner>` when anything is declared.
+
+Four rules worth knowing before you rely on this:
+
+- **Registration does no I/O.** It records intent and validates; it does not
+  clone, read or fetch. `init_sparkrun` runs on every shell completion, so
+  anything expensive here lands on the interactive path — which is also why a
+  plugin cannot point at a remote `.sparkrun/registry.yaml` and have its
+  *names* come from there. Declare them in code; the repo manifest stays for
+  users who add the registry by URL by hand.
+- **Trust depends on where the plugin came from.** An in-tree plugin may ship
+  `trusted=True` (it arrives through sparkrun's own review and release gate).
+  For an out-of-tree plugin it is forced to `False` and the user grants it with
+  `sparkrun registry trust <name>` — installing a plugin says "I want this
+  capability", not "I grant its recipe repo standing permission to run
+  lifecycle hooks from whatever it contains next month". Document that step in
+  your install instructions if your recipes use `pre_exec` / `post_exec` /
+  `post_commands`. The tier is set by the loader; a plugin cannot claim it.
+- **Names are validated at declaration and raise.** `validate_registry_name`
+  checks the *registry URL's* GitHub org against the reserved-name tables, and
+  `assert_safe_registry_entry` checks the name and every subpath as filesystem
+  paths. A reserved name from the wrong org fails at bootstrap, not later — so
+  if you want a name reserved to your org, that entry belongs in
+  `EXTERNAL_RESERVED_NAMES` in core.
+- **You cannot redefine a shipped default.** Declaring `official` is refused
+  with a warning naming your plugin, rather than silently ignored. A new name
+  is the supported use; shadowing a curated one is not.
+
+Nothing is fetched until something clones it, so suggest `sparkrun registry
+update` after your plugin is first enabled rather than paying a clone inside
+the next `sparkrun run`.

--- a/src/sparkrun/api/_run.py
+++ b/src/sparkrun/api/_run.py
@@ -652,6 +652,7 @@ def _evict_superseded_deployments(
     cluster_def,
     config,
     sctx: "SparkrunContext | None",
+    strict: bool = False,
 ) -> "tuple[list[str], set[str] | None]":
     """Stop this intent's earlier deployments that sit on the hosts we're about to use.
 
@@ -682,8 +683,11 @@ def _evict_superseded_deployments(
       within *candidate_hosts*, not just the overlapping ones — half a
       distributed job is dead weight either way.
 
-    Best-effort: discovery or teardown failures are logged and swallowed so
-    they can't block a launch that may well succeed anyway.
+    Discovery and teardown are best-effort by default so they cannot block a
+    normal launch that may still succeed.  Callers that must bind the same
+    host resources before their own launcher starts can set ``strict=True``;
+    then an unverified replacement aborts instead of predictably colliding
+    with the earlier workload.
 
     Returns:
         ``(evicted, observed_running)`` — the cluster_ids torn down (empty when
@@ -707,6 +711,8 @@ def _evict_superseded_deployments(
             v=sctx.variables if sctx is not None else None,
         )
     except Exception as e:
+        if strict:
+            raise RuntimeError("could not query cluster status before workload replacement: %s" % e) from e
         logger.debug("Could not query cluster status for eviction; skipping: %s", e)
         return [], None
 
@@ -740,9 +746,13 @@ def _evict_superseded_deployments(
         try:
             result = api.stop(cluster_id=cid, hosts=occupied[cid], cluster=cluster_def, sctx=sctx)
         except Exception as e:
+            if strict:
+                raise RuntimeError("could not stop earlier deployment %s: %s" % (cid, e)) from e
             logger.warning("Could not stop earlier deployment %s: %s — it may still hold GPU memory", cid, e)
             continue
         if result.hosts_failed:
+            if strict:
+                raise RuntimeError("teardown of earlier deployment %s was not confirmed on %s" % (cid, ", ".join(result.hosts_failed)))
             logger.warning(
                 "Teardown of earlier deployment %s did not confirm on %s — it may still hold GPU memory",
                 cid,

--- a/src/sparkrun/cli/_registry.py
+++ b/src/sparkrun/cli/_registry.py
@@ -66,6 +66,10 @@ def registry_list(ctx, show_disabled, only_show_visible, output_json, config_pat
     # Determine which content columns to show
     has_tuning = any(r.tuning_subpath for r in display_registries)
     has_benchmarks = any(r.benchmark_subpath for r in display_registries)
+    # Only shown when something is plugin-declared: a user who did not add a
+    # registry should be able to see who did, but the column is noise on the
+    # overwhelmingly common all-local list.
+    has_declared = any(r.declared_by for r in display_registries)
 
     # Table header
     # "Stemless" is `visible`: whether a bare recipe stem resolves against this
@@ -78,6 +82,9 @@ def registry_list(ctx, show_disabled, only_show_visible, output_json, config_pat
     if has_benchmarks:
         header += f" {'Bench':<7}"
         sep_width += 8
+    if has_declared:
+        header += f" {'Source':<16}"
+        sep_width += 17
     click.echo(header)
     click.echo("-" * sep_width)
 
@@ -93,6 +100,9 @@ def registry_list(ctx, show_disabled, only_show_visible, output_json, config_pat
         if has_benchmarks:
             bench = "yes" if reg.benchmark_subpath else "no"
             row += f" {bench:<7}"
+        if has_declared:
+            source = ("plugin:%s" % reg.declared_by) if reg.declared_by else "config"
+            row += f" {source[:16]:<16}"
         click.echo(row)
 
 
@@ -202,9 +212,24 @@ def registry_remove(ctx, name, config_path=None):
 
     config, registry_mgr = _get_config_and_registry(config_path)
 
+    # Read the provenance before removing, so the message can be honest about
+    # what actually happened: a plugin-declared registry is suppressed rather
+    # than deleted (there is nothing in registries.yaml to delete), and saying
+    # "removed successfully" without that would leave the user unable to explain
+    # why re-enabling the plugin does not bring it back.
+    declared_by = ""
+    try:
+        declared_by = registry_mgr.get_registry(name).declared_by
+    except RegistryError:
+        pass
+
     try:
         registry_mgr.remove_registry(name)
-        click.echo(f"Registry '{name}' removed successfully.")
+        if declared_by:
+            click.echo(f"Registry '{name}' (declared by plugin '{declared_by}') removed and suppressed.")
+            click.echo(f"  It will not return while '{declared_by}' is installed. Undo with: sparkrun registry add <url>")
+        else:
+            click.echo(f"Registry '{name}' removed successfully.")
     except RegistryError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
@@ -301,6 +326,8 @@ def registry_show(ctx, name, config_path=None):
     click.echo("Enabled:     %s" % ("yes" if entry.enabled else "no"))
     click.echo("Stemless:    %s" % ("yes" if entry.visible else "no"))
     click.echo("Trusted:     %s" % ("yes" if entry.trusted else "no"))
+    if entry.declared_by:
+        click.echo("Source:      declared by plugin '%s' (not in your configuration)" % entry.declared_by)
     if entry.tuning_subpath:
         click.echo("Tuning:      %s" % entry.tuning_subpath)
     if entry.benchmark_subpath:

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -70,6 +70,14 @@ _EXECUTOR_OVERRIDE_KEYS = frozenset(
 )
 
 
+def _timing_tree_depth(ctx: click.Context) -> int | None:
+    """Choose the ordinary ``run`` timing detail from global verbosity."""
+    verbose_count = (ctx.find_root().obj or {}).get("verbose", 0)
+    if isinstance(verbose_count, bool):
+        verbose_count = 1 if verbose_count else 0
+    return None if verbose_count >= 3 else max(2, 2 + verbose_count)
+
+
 def _echo_hub_notice() -> None:
     """Report skipped HuggingFace Hub lookups, at most once per command.
 
@@ -940,7 +948,7 @@ def run(
     if show_timings and sctx.timing is not None:
         from sparkrun.utils.cli_formatters import format_launch_timings
 
-        _timings = format_launch_timings(sctx.timing.export())
+        _timings = format_launch_timings(sctx.timing.export(), max_depth=_timing_tree_depth(ctx))
         if _timings:
             click.echo()
             click.echo(_timings)

--- a/src/sparkrun/core/cluster_manager.py
+++ b/src/sparkrun/core/cluster_manager.py
@@ -198,6 +198,15 @@ class ClusterDefinition:
     description: str = ""
     user: str | None = None
     cache_dir: str | None = None
+    sparkrun_cache_dir: str | None = None
+    """Remote cluster-specific sparkrun state/cache root.
+
+    This is independent of :attr:`cache_dir`, which remains the remote Hugging
+    Face/model cache.  Consumers derive their own subdirectories unless a
+    narrower plugin setting overrides them.
+    """
+    plugins: dict[str, dict[str, Any]] = field(default_factory=dict)
+    """Cluster-local plugin settings, layered above user plugin defaults."""
     transfer_mode: str | None = None
     transfer_interface: str | None = None
     topology: str | None = None
@@ -382,6 +391,16 @@ class ClusterDefinition:
             return default_dgx_spark_hardware()
         return hw
 
+    def plugin_settings(self, name: str) -> dict[str, Any]:
+        """Return an isolated, validated cluster-local plugin mapping."""
+
+        raw = self.plugins.get(name, {})
+        if not isinstance(raw, dict):
+            raise ClusterError("cluster '%s' plugins.%s must be a mapping" % (self.name, name))
+        if "paths" in raw:
+            raise ClusterError("cluster '%s' plugins.%s cannot declare plugin discovery paths" % (self.name, name))
+        return dict(raw)
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to a JSON-serializable dictionary (omits None optional fields)."""
         d: dict[str, Any] = {"name": self.name, "hosts": self.hosts, "description": self.description}
@@ -389,6 +408,10 @@ class ClusterDefinition:
             d["user"] = self.user
         if self.cache_dir:
             d["cache_dir"] = self.cache_dir
+        if self.sparkrun_cache_dir:
+            d["sparkrun_cache_dir"] = self.sparkrun_cache_dir
+        if self.plugins:
+            d["plugins"] = {name: dict(settings) for name, settings in self.plugins.items()}
         if self.transfer_mode:
             d["transfer_mode"] = self.transfer_mode
         if self.transfer_interface:
@@ -586,6 +609,8 @@ class ClusterManager:
         scheduler: str | None = None,
         max_gpu_memory_utilization: float | None = None,
         distribution: ClusterDistributionConfig | None = None,
+        sparkrun_cache_dir: str | None = None,
+        plugins: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         """Create a new named cluster.
 
@@ -595,6 +620,8 @@ class ClusterManager:
             description: Optional cluster description
             user: Optional SSH username for this cluster
             cache_dir: Optional HuggingFace cache directory for this cluster
+            sparkrun_cache_dir: Optional remote sparkrun state/cache root
+            plugins: Optional cluster-local plugin settings
             transfer_mode: Optional transfer mode (local, push, delegated)
             transfer_interface: Optional transfer interface (cx7, mgmt)
             topology: Optional CX7 topology (direct, switch, ring)
@@ -633,6 +660,8 @@ class ClusterManager:
             description=description,
             user=user,
             cache_dir=cache_dir,
+            sparkrun_cache_dir=sparkrun_cache_dir,
+            plugins={name: dict(settings) for name, settings in (plugins or {}).items()},
             transfer_mode=transfer_mode,
             transfer_interface=transfer_interface,
             topology=topology,
@@ -650,6 +679,8 @@ class ClusterManager:
             max_gpu_memory_utilization=max_gpu_memory_utilization,
             distribution=distribution if distribution is not None else ClusterDistributionConfig(),
         )
+        for plugin in cluster_def.plugins:
+            cluster_def.plugin_settings(plugin)
         self._write_cluster(cluster_def)
         logger.info("Created cluster '%s' with %d hosts", name, len(hosts))
 
@@ -692,6 +723,8 @@ class ClusterManager:
         scheduler: str | None = _UNSET,
         max_gpu_memory_utilization: float | None = _UNSET,
         distribution: ClusterDistributionConfig | None = _UNSET,
+        sparkrun_cache_dir: str | None = _UNSET,
+        plugins: dict[str, dict[str, Any]] | None = _UNSET,
     ) -> None:
         """Update existing cluster definition.
 
@@ -701,6 +734,10 @@ class ClusterManager:
             description: New description (if provided)
             user: SSH username (if provided; pass ``None`` explicitly to clear)
             cache_dir: HuggingFace cache directory (if provided; pass ``None`` explicitly to clear)
+            sparkrun_cache_dir: Remote sparkrun state/cache root (if provided;
+                pass ``None`` explicitly to clear)
+            plugins: Cluster-local plugin settings (if provided; pass an empty
+                mapping to clear)
             transfer_mode: Transfer mode (if provided; pass ``None`` explicitly to clear)
             transfer_interface: Transfer interface (if provided; pass ``None`` explicitly to clear)
             topology: CX7 topology (if provided; pass ``None`` explicitly to clear)
@@ -733,6 +770,16 @@ class ClusterManager:
         if cache_dir is not _UNSET:
             cluster_def.cache_dir = cache_dir
             logger.debug("Updated cache_dir for cluster '%s'", name)
+
+        if sparkrun_cache_dir is not _UNSET:
+            cluster_def.sparkrun_cache_dir = sparkrun_cache_dir
+            logger.debug("Updated sparkrun_cache_dir for cluster '%s'", name)
+
+        if plugins is not _UNSET:
+            cluster_def.plugins = {plugin: dict(settings) for plugin, settings in (plugins or {}).items()}
+            for plugin in cluster_def.plugins:
+                cluster_def.plugin_settings(plugin)
+            logger.debug("Updated plugin settings for cluster '%s'", name)
 
         if transfer_mode is not _UNSET:
             if transfer_mode is not None and transfer_mode not in VALID_TRANSFER_MODES:
@@ -904,6 +951,10 @@ class ClusterManager:
             data["user"] = cluster_def.user
         if cluster_def.cache_dir is not None:
             data["cache_dir"] = cluster_def.cache_dir
+        if cluster_def.sparkrun_cache_dir is not None:
+            data["sparkrun_cache_dir"] = cluster_def.sparkrun_cache_dir
+        if cluster_def.plugins:
+            data["plugins"] = {name: dict(settings) for name, settings in cluster_def.plugins.items()}
         if cluster_def.transfer_mode is not None:
             data["transfer_mode"] = cluster_def.transfer_mode
         if cluster_def.transfer_interface is not None:
@@ -982,6 +1033,17 @@ class ClusterManager:
         raw_env = data.get("env") or {}
         cluster_env: dict[str, str] = {str(k): str(v) for k, v in raw_env.items()} if isinstance(raw_env, dict) else {}
 
+        raw_plugins = data.get("plugins") or {}
+        plugins: dict[str, dict[str, Any]] = {}
+        if not isinstance(raw_plugins, dict):
+            raise ClusterError("cluster plugins must be a mapping")
+        for name, settings in raw_plugins.items():
+            if not isinstance(name, str) or not name or not isinstance(settings, dict):
+                raise ClusterError("cluster plugin settings are invalid")
+            if "paths" in settings:
+                raise ClusterError("cluster plugins.%s cannot declare plugin discovery paths" % name)
+            plugins[name] = dict(settings)
+
         accelerator_memory_limits: dict[str, float] = {}
         raw_accel_limits = data.get("accelerator_memory_limits")
         if isinstance(raw_accel_limits, dict):
@@ -997,6 +1059,8 @@ class ClusterManager:
             description=data.get("description", ""),
             user=data.get("user"),
             cache_dir=data.get("cache_dir"),
+            sparkrun_cache_dir=data.get("sparkrun_cache_dir"),
+            plugins=plugins,
             transfer_mode=data.get("transfer_mode"),
             transfer_interface=data.get("transfer_interface"),
             topology=data.get("topology"),

--- a/src/sparkrun/core/external_plugins.py
+++ b/src/sparkrun/core/external_plugins.py
@@ -54,6 +54,8 @@ from sparkrun.core.features import FEATURE_CORE_EXTERNAL_PLUGINS, feature_gate_e
 if TYPE_CHECKING:
     from scitrera_app_framework import Variables
 
+    from sparkrun.core.registry_defaults import DeclarationTier
+
 logger = logging.getLogger(__name__)
 
 # Hard test/CI kill-switch for the config-driven auto-load path — set truthy to
@@ -122,33 +124,48 @@ def _scan_module_for_plugins(module, base: type) -> list[type]:
     return list(found.values())
 
 
-def load_plugin_module(module, v: "Variables") -> None:
+def load_plugin_module(module, v: "Variables", *, tier: "DeclarationTier | None" = None) -> None:
     """Register everything *module* contributes: SAF subclasses, then ``register(v)``.
 
     Shared with :mod:`sparkrun.core.in_tree_plugins` — in-tree and out-of-tree
     plugins differ only in where their modules come from, so they must not
     differ in what counts as a registration.
-    """
-    # 1) Register SAF-scanned plugin subclasses (runtimes/executors/transports/…).
-    for base in _plugin_base_types():
-        for cls in _scan_module_for_plugins(module, base):
-            if not _is_registerable(cls):
-                continue
-            try:
-                register_plugin(cls, v=v)
-                logger.debug("Registered external plugin %s from %s", cls.__name__, module.__name__)
-            except (ValueError, TypeError) as e:
-                logger.debug("Skipping external plugin %s: %s", cls.__name__, e)
 
-    # 2) Optional explicit hook — the home for in-process registrations
-    #    (register_platform, collective backends) and any bespoke wiring.
-    hook = getattr(module, "register", None)
-    if callable(hook):
-        try:
-            hook(v)
-            logger.debug("Ran register(v) hook for external plugin module %s", module.__name__)
-        except Exception:  # noqa: BLE001 - a bad third-party hook must not crash startup
-            logger.exception("register(v) hook failed for external plugin module %s", module.__name__)
+    Args:
+        module: The imported plugin module or package.
+        v: The initialized SAF :class:`~scitrera_app_framework.Variables`.
+        tier: Provenance to attribute this module's registry declarations to
+            (see :mod:`sparkrun.core.registry_defaults`).  Supplied by the
+            *loader* because a plugin must not be able to claim its own tier —
+            an in-tree tier is what lets a declaration ship trusted.  Ambient
+            for the duration of the load rather than an argument, since the
+            plugin makes the registration call, not us.  Defaults to
+            ``OUT_OF_TREE``: least privilege.
+    """
+    from sparkrun.core.registry_defaults import DeclarationTier, declaring_tier
+
+    with declaring_tier(tier or DeclarationTier.OUT_OF_TREE):
+        # 1) Register SAF-scanned plugin subclasses (runtimes/executors/transports/…).
+        for base in _plugin_base_types():
+            for cls in _scan_module_for_plugins(module, base):
+                if not _is_registerable(cls):
+                    continue
+                try:
+                    register_plugin(cls, v=v)
+                    logger.debug("Registered external plugin %s from %s", cls.__name__, module.__name__)
+                except (ValueError, TypeError) as e:
+                    logger.debug("Skipping external plugin %s: %s", cls.__name__, e)
+
+        # 2) Optional explicit hook — the home for in-process registrations
+        #    (register_platform, collective backends, register_default_registry)
+        #    and any bespoke wiring.
+        hook = getattr(module, "register", None)
+        if callable(hook):
+            try:
+                hook(v)
+                logger.debug("Ran register(v) hook for external plugin module %s", module.__name__)
+            except Exception:  # noqa: BLE001 - a bad third-party hook must not crash startup
+                logger.exception("register(v) hook failed for external plugin module %s", module.__name__)
 
 
 def _configured_paths(v: "Variables") -> list[Path]:

--- a/src/sparkrun/core/in_tree_plugins.py
+++ b/src/sparkrun/core/in_tree_plugins.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING
 
 from sparkrun.core.external_plugins import load_plugin_module
 from sparkrun.core.features import feature_gate_enabled, get_feature
+from sparkrun.core.registry_defaults import DeclarationTier
 
 if TYPE_CHECKING:
     from scitrera_app_framework import Variables
@@ -123,7 +124,11 @@ def load_in_tree_plugins(v: "Variables", package: str = IN_TREE_PLUGIN_PACKAGE) 
             # say so loudly.
             logger.exception("Failed to import in-tree plugin %r", dotted)
             continue
-        load_plugin_module(module, v)
+        # IN_TREE is what lets this plugin's registry declarations ship trusted
+        # (sparkrun.core.registry_defaults). Asserted by the loader, never by
+        # the plugin — including for a vendored plugin, where the claim rests on
+        # the pinned commit in vendor/*.lock and the review of the import PR.
+        load_plugin_module(module, v, tier=DeclarationTier.IN_TREE)
         loaded.append(name)
 
     if loaded:

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -22,6 +22,7 @@ from sparkrun.core.timing import ROOT as TIMELINE_ROOT, STATUS_ERROR, Timeline, 
 
 if TYPE_CHECKING:
     from sparkrun.core.backend_select import BackendBundle
+    from sparkrun.core.cluster_manager import ClusterDefinition
     from sparkrun.core.config import SparkrunConfig
     from sparkrun.core.context import SparkrunContext
     from sparkrun.core.progress import LaunchProgress
@@ -480,6 +481,7 @@ def resolve_effective_runtime_cache_dir(
     ssh_kwargs: dict,
     config: SparkrunConfig,
     dry_run: bool = False,
+    cluster: ClusterDefinition | None = None,
 ) -> str:
     """Resolve the target hosts' sparkrun cache dir for the runtime cache.
 
@@ -490,6 +492,10 @@ def resolve_effective_runtime_cache_dir(
     cache is an optimization, and a wrong guess costs a recompile (the
     directory simply won't pre-exist) while an exception would cost the launch.
     """
+    configured = getattr(cluster, "sparkrun_cache_dir", None)
+    if configured:
+        return str(configured)
+
     from sparkrun.utils import is_local_host
     from sparkrun.orchestration.primitives import probe_remote_sparkrun_cache
 
@@ -1754,7 +1760,13 @@ def launch_inference(
         if _rc_settings.enabled:
             _rc_root = resolve_runtime_cache_root(
                 _rc_settings,
-                resolve_effective_runtime_cache_dir(host_list, ssh_kwargs, config, dry_run=dry_run),
+                resolve_effective_runtime_cache_dir(
+                    host_list,
+                    ssh_kwargs,
+                    config,
+                    dry_run=dry_run,
+                    cluster=cluster,
+                ),
             )
             # Derived *after* apply_platform_runtime_flag_defaults, deliberately.
             # The fingerprint then reflects the platform flags this hardware

--- a/src/sparkrun/core/progress.py
+++ b/src/sparkrun/core/progress.py
@@ -30,9 +30,10 @@ import logging
 import re
 import threading
 import time
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from enum import IntEnum
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sparkrun.core.timing import Timeline
@@ -52,7 +53,11 @@ DEFAULT_HEARTBEAT_SECONDS = 30.0
 
 
 @contextmanager
-def progress_heartbeat(logger: logging.Logger, label: str, interval: float = DEFAULT_HEARTBEAT_SECONDS) -> Iterator[None]:
+def progress_heartbeat(
+    logger: logging.Logger,
+    label: str | Callable[[], str],
+    interval: float = DEFAULT_HEARTBEAT_SECONDS,
+) -> Iterator[None]:
     """Keep a long operation visibly alive at the standard progress level.
 
     For work that emits nothing while it runs — a multi-minute image build, a
@@ -65,7 +70,8 @@ def progress_heartbeat(logger: logging.Logger, label: str, interval: float = DEF
 
     def report() -> None:
         while not stopped.wait(interval):
-            logger.log(PROGRESS, "%s — still running (%.0fs)", label, time.monotonic() - started)
+            current_label = label() if callable(label) else label
+            logger.log(PROGRESS, "%s — still running (%.0fs)", current_label, time.monotonic() - started)
 
     thread = threading.Thread(target=report, name="sparkrun-progress-heartbeat", daemon=True)
     thread.start()

--- a/src/sparkrun/core/registry.py
+++ b/src/sparkrun/core/registry.py
@@ -135,6 +135,15 @@ class RegistryEntry:
             confirmation prompt.  Defaults to False so user-added third-party
             registries are untrusted until explicitly opted-in via
             ``sparkrun registry trust <name>`` or ``registry add --trust``.
+        declared_by: Name of the plugin that declared this registry, or ``""``
+            for an ordinary user-owned entry read from ``registries.yaml``.
+            **Runtime-only and never serialized** — see
+            :mod:`sparkrun.core.registry_defaults`.  A declared entry is an
+            overlay: it exists while its plugin is loaded and is not written to
+            the config file, which is what makes uninstalling a plugin remove
+            its registries cleanly.  Mutating one (``registry disable`` /
+            ``trust`` / ``untrust``) *materializes* it by clearing this field,
+            after which it is an ordinary file entry the user owns.
     """
 
     name: str
@@ -147,6 +156,7 @@ class RegistryEntry:
     benchmark_subpath: str = ""
     mods_subpath: str = ""
     trusted: bool = False
+    declared_by: str = ""
 
 
 #: Asset subpaths a registry may omit.  Shared with
@@ -466,6 +476,15 @@ def _normalize_registry_url(url: str) -> str:
 #: migrating".
 CONFIG_VERSION = 1
 
+#: Top-level ``registries.yaml`` key holding names the user removed that a
+#: plugin still declares (see :meth:`RegistryManager._load_suppressed`).
+#:
+#: Additive: an older sparkrun ignores an unknown top-level key, and the overlay
+#: is not a file rewrite, so this needs no :data:`CONFIG_VERSION` bump.  Per the
+#: :data:`_MIGRATIONS` docstring, only migrations that cannot detect their own
+#: applicability from file content belong there.
+SUPPRESSED_REGISTRIES_KEY = "suppressed_plugin_registries"
+
 #: Version implied by a file that carries no ``config_version`` key but does
 #: carry an explicit per-entry ``trusted`` field — i.e. one written after the
 #: trust model landed but before the marker did.
@@ -598,6 +617,15 @@ RESERVED_PREFIX_ALLOWED_ORGS = (
 # which lowercases the URL path component before returning.
 EXTERNAL_RESERVED_NAMES = {
     "atlas": ("atlas-inf",),
+    # ColdSnap's recipe registries, declared by the in-tree ColdSnap plugin (see
+    # sparkrun.core.registry_defaults).  Exact-match rather than a
+    # RESERVED_NAME_PREFIXES entry on purpose: RESERVED_PREFIX_ALLOWED_ORGS is a
+    # *global* allowlist, so covering "coldsnap-*" that way would also grant
+    # sparksq every other reserved prefix (official-*, sparkrun-*, arena-*).
+    # That may be a reasonable thing to decide later; it is not a side effect
+    # this reservation should smuggle in.
+    "coldsnap": ("sparksq",),
+    "coldsnap-vanilla": ("sparksq",),
 }
 
 
@@ -1049,6 +1077,93 @@ class RegistryManager:
         """Get the recipe directory within a cached registry."""
         return self.asset_dir(entry, RECIPE_ASSET)
 
+    def _load_suppressed(self) -> list[str]:
+        """Names the user removed that a plugin still declares (tombstones).
+
+        ``registry remove`` on a declared registry cannot simply drop it — the
+        declaration would put it straight back on the next launch, which is
+        indistinguishable from a bug.  So the removal is recorded here instead.
+        Kept as a plain list under :data:`SUPPRESSED_REGISTRIES_KEY` in
+        ``registries.yaml``; an older sparkrun ignores the key.
+        """
+        if not self._registries_path.exists():
+            return []
+        try:
+            data = read_yaml(self._registries_path)
+        except Exception:
+            return []
+        if not isinstance(data, dict):
+            return []
+        raw = data.get(SUPPRESSED_REGISTRIES_KEY) or []
+        if not isinstance(raw, list):
+            return []
+        return [str(name) for name in raw if isinstance(name, str) and name]
+
+    def _apply_plugin_overlay(self, entries: list[RegistryEntry]) -> list[RegistryEntry]:
+        """Merge plugin-declared registries onto the user's own entries.
+
+        Applied *after* every convergent rewrite and after any save, so declared
+        entries never enter the migration or persistence path — the overlay is
+        computed fresh on each load and only the user's file is durable.
+
+        Resolution, in order:
+
+        1. **A collision with a shipped default is refused and warned.**  The
+           declaration loses.  Refusing rather than ranking is deliberate: the
+           legitimate use of this seam is contributing a *new* name, and letting
+           a declaration silently shadow a curated one would be a namespace
+           redirect that ``validate_registry_name`` cannot catch (it only guards
+           *reserved* names).  Pathological, so make it loud.
+
+           Checked **first**, before the file-entry rule below, precisely so it
+           is loud in the common case too: a shipped default is normally present
+           in the user's file, so an ordering that let rule 2 match first would
+           silently ignore a plugin trying to redefine ``official`` — the one
+           case most worth reporting.
+        2. **A file entry of the same name wins outright, silently.**  That is
+           the supported override (materialize-on-mutation puts entries there,
+           and it is how a user repoints a declared registry at an internal
+           mirror), so it is a normal outcome, not a conflict.
+        3. **A tombstone suppresses**, likewise silently — the user said no.
+        """
+        from sparkrun.core.registry_defaults import iter_declared_registries
+
+        declarations = iter_declared_registries()
+        if not declarations:
+            return entries
+
+        existing = {e.name for e in entries}
+        suppressed = set(self._load_suppressed())
+        shipped = {e.name for e in FALLBACK_DEFAULT_REGISTRIES}
+
+        merged = list(entries)
+        for declaration in declarations:
+            name = declaration.entry.name
+            if name in shipped:
+                logger.warning(
+                    "Plugin %r declares registry %r, which is a shipped default; ignoring the declaration",
+                    declaration.owner,
+                    name,
+                )
+                continue
+            if name in existing:
+                logger.debug(
+                    "Registry %r is configured locally; ignoring the declaration from plugin %r",
+                    name,
+                    declaration.owner,
+                )
+                continue
+            if name in suppressed:
+                logger.debug(
+                    "Registry %r declared by plugin %r was removed by the user; not re-adding",
+                    name,
+                    declaration.owner,
+                )
+                continue
+            merged.append(declaration.effective_entry())
+            existing.add(name)
+        return merged
+
     def _default_registries(self) -> list[RegistryEntry]:
         """Return the default registry list.
 
@@ -1087,11 +1202,13 @@ class RegistryManager:
                 combined.append(_dataclass_replace(fallback))
                 seen_names.add(fallback.name)
 
-        # Persist so subsequent _load_registries() reads from file
+        # Persist so subsequent _load_registries() reads from file.  The overlay
+        # is applied *after* this, so a declared registry is never written into
+        # a fresh registries.yaml either.
         if discovered:
             self._save_registries(combined)
 
-        return combined
+        return self._apply_plugin_overlay(combined)
 
     def _init_defaults_from_manifests(self) -> list[RegistryEntry]:
         """Try to discover default registries from git manifest files.
@@ -1415,19 +1532,38 @@ class RegistryManager:
 
             if migrated or urls_migrated or subpaths_backfilled:
                 self._save_registries(filtered)
-            return filtered
+            # Overlay last: declared entries must not reach the rewrite or save
+            # path above, or a plugin's registry would be persisted into the
+            # user's file and outlive the plugin.
+            return self._apply_plugin_overlay(filtered)
         except Exception as e:
             logger.warning("Failed to load registries.yaml: %s", e)
             return self._default_registries()
 
-    def _save_registries(self, entries: list[RegistryEntry]) -> None:
+    def _save_registries(self, entries: list[RegistryEntry], *, suppressed: list[str] | None = None) -> None:
         """Save registries to YAML configuration.
 
+        Plugin-declared entries (``declared_by`` set) are **skipped**.  Every
+        mutating command reads through :meth:`_load_registries`, which now
+        includes the overlay, and each of them rewrites the whole document — so
+        without this filter the first ``registry disable`` of anything would
+        quietly persist every declared registry, and they would then outlive
+        their plugin.  Materializing one is done by *clearing* ``declared_by``
+        (see :meth:`_materialize_declared`), which is what lets it through here.
+
         Args:
-            entries: List of registry entries to save
+            entries: Registry entries to save; declared entries are ignored.
+            suppressed: Tombstone list to write.  ``None`` preserves whatever is
+                already on disk — this method rebuilds the document from
+                scratch, so anything not re-emitted is dropped.
         """
+        if suppressed is None:
+            suppressed = self._load_suppressed()
+
         data_list = []
         for e in entries:
+            if e.declared_by:
+                continue
             d: dict[str, Any] = {"name": e.name, "url": e.url, "subpath": e.subpath}
             if e.description:
                 d["description"] = e.description
@@ -1456,7 +1592,9 @@ class RegistryManager:
         # Stamped on every write, not just by the migration runner: this method
         # rebuilds the document from scratch, so anything it didn't re-emit
         # would be silently dropped.
-        data = {"config_version": CONFIG_VERSION, "registries": data_list}
+        data: dict[str, Any] = {"config_version": CONFIG_VERSION, "registries": data_list}
+        if suppressed:
+            data[SUPPRESSED_REGISTRIES_KEY] = sorted(set(suppressed))
         with open(self._registries_path, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
         logger.debug("Saved registries to %s", self._registries_path)
@@ -1834,7 +1972,12 @@ class RegistryManager:
         if any(r.name == entry.name for r in registries):
             raise RegistryError(f"Registry {entry.name!r} already exists")
         registries.append(entry)
-        self._save_registries(registries)
+        # Adding a name back is an explicit reversal of a prior removal, so it
+        # clears any tombstone.  Otherwise a user who removed a plugin-declared
+        # registry and later re-added it under their own URL would keep a
+        # suppression entry that silences the declaration forever, invisibly.
+        suppressed = [name for name in self._load_suppressed() if name != entry.name]
+        self._save_registries(registries, suppressed=suppressed)
         logger.info("Added registry %s", entry.name)
 
     def _discover_manifest_entries(self, url: str) -> list[RegistryEntry]:
@@ -1970,8 +2113,32 @@ class RegistryManager:
                 entry.trusted = True
         return added
 
+    @staticmethod
+    def _materialize_declared(entry: RegistryEntry) -> None:
+        """Turn a plugin-declared entry into a user-owned one, in place.
+
+        Clearing ``declared_by`` is what lets :meth:`_save_registries` write it.
+        After this the file entry wins over the declaration
+        (:meth:`_apply_plugin_overlay` rule 1), so the user's change is durable
+        and survives the plugin being upgraded, disabled or removed — which is
+        the point: they took ownership of it.
+        """
+        if entry.declared_by:
+            logger.info(
+                "Registry %r was declared by plugin %r; saving it to your configuration so this change persists",
+                entry.name,
+                entry.declared_by,
+            )
+            entry.declared_by = ""
+
     def remove_registry(self, name: str) -> None:
         """Remove a registry by name.
+
+        A plugin-declared registry is **tombstoned** rather than deleted: it is
+        not in ``registries.yaml`` to remove, and dropping it from the in-memory
+        list would let the declaration put it straight back on the next launch —
+        a removal that silently fails to remove. The tombstone is cleared by
+        adding the registry back (:meth:`add_registry`).
 
         Args:
             name: Registry name to remove
@@ -1980,9 +2147,23 @@ class RegistryManager:
             RegistryError: If the registry is not found
         """
         registries = self._load_registries()
-        filtered = [r for r in registries if r.name != name]
-        if len(filtered) == len(registries):
+        target = next((r for r in registries if r.name == name), None)
+        if target is None:
             raise RegistryError(f"Registry {name!r} not found")
+
+        filtered = [r for r in registries if r.name != name]
+        if target.declared_by:
+            suppressed = self._load_suppressed()
+            if name not in suppressed:
+                suppressed.append(name)
+            self._save_registries(filtered, suppressed=suppressed)
+            logger.info(
+                "Removed registry %s (declared by plugin %r; suppressed so it is not re-added)",
+                name,
+                target.declared_by,
+            )
+            return
+
         self._save_registries(filtered)
         logger.info("Removed registry %s", name)
 
@@ -2140,6 +2321,7 @@ class RegistryManager:
         for e in entries:
             if e.name == name:
                 e.enabled = enabled
+                self._materialize_declared(e)
                 self._save_registries(entries)
                 logger.info("%s registry %s", "Enabled" if enabled else "Disabled", name)
                 return
@@ -2175,6 +2357,7 @@ class RegistryManager:
         for e in entries:
             if e.name == name:
                 e.trusted = trusted
+                self._materialize_declared(e)
                 self._save_registries(entries)
                 logger.info("%s registry %s", "Trusted" if trusted else "Untrusted", name)
                 return

--- a/src/sparkrun/core/registry_defaults.py
+++ b/src/sparkrun/core/registry_defaults.py
@@ -1,0 +1,227 @@
+"""Registries a plugin declares should exist while it is loaded.
+
+The shipped defaults (:data:`sparkrun.core.registry.BOOTSTRAP_REGISTRY_URLS` and
+:data:`~sparkrun.core.registry.FALLBACK_DEFAULT_REGISTRIES`) are closed
+constants.  This module is the extension point beside them: a plugin whose
+recipes are inert without it — ColdSnap is the first — declares its registry
+here, and it becomes resolvable (``@coldsnap/<recipe>``) for anyone with the
+plugin enabled, without the user adding anything.
+
+An **in-process** registry, like :mod:`sparkrun.platforms` and
+:func:`sparkrun.models.kv.register_kv_strategy`, rather than a SAF extension
+point: registration must be cheap (it runs on every CLI invocation, including
+shell completion — see below), ordered by the plugin loader, and reachable from
+a plugin's ``register(v)`` hook.
+
+**Registration performs no I/O.**  It records intent and validates; nothing is
+cloned, read or written.  This is not a nicety: shell completion runs
+``init_sparkrun`` on every ``<TAB>`` (Click resolves the command tree through
+``PluggableGroup.get_command``), so anything expensive here lands on the
+interactive path.  It is also why a plugin cannot point at a remote manifest and
+have its *names* come from there — the overlay has to be computable offline.
+
+**Declarations are an overlay, never persisted.**  ``RegistryManager`` merges
+them into the list it loads; ``registries.yaml`` keeps only what the user owns.
+So uninstalling or disabling a plugin removes its registries with it, and there
+is no orphaned entry to reap.  User decisions still stick — mutating a declared
+registry (``registry disable`` / ``trust`` / ``untrust``) *materializes* it into
+the file, after which the file wins; ``registry remove`` records a tombstone.
+
+Tier
+----
+:class:`DeclarationTier` records **who vouches for** a declaration, and decides
+whether a ``trusted=True`` claim is honored (see
+:meth:`DeclaredRegistry.effective_entry`).  It is supplied by the **loader**,
+never by the plugin: ``load_plugin_module`` wraps registration in
+:func:`declaring_tier`, and a call made outside any loader is treated as
+``OUT_OF_TREE`` — least privilege, so nothing can acquire in-tree trust by
+registering from an unexpected place.
+
+(The design note originally proposed threading the tier as an explicit argument.
+That is not implementable: the *plugin* makes the call, so the loader has no
+argument to thread — the value has to be ambient for the duration of the load.)
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, replace as _dataclass_replace
+from enum import Enum
+from typing import Iterator
+
+from sparkrun.core.registry import (
+    RegistryEntry,
+    RegistryError,
+    assert_safe_registry_entry,
+    validate_registry_name,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DeclarationTier(Enum):
+    """Provenance of a plugin declaration."""
+
+    #: Ships inside the sparkrun distribution (``sparkrun.plugins.*``), whether
+    #: authored here or vendored in under ``vendor/*.lock``.
+    IN_TREE = "in-tree"
+
+    #: Loaded from a user-configured ``plugins.paths`` directory.
+    OUT_OF_TREE = "out-of-tree"
+
+
+#: Ambient tier for the duration of a plugin load.  ``OUT_OF_TREE`` is the
+#: default because it is the *less* privileged of the two: a declaration made
+#: outside a loader — a stray import, a test, a plugin calling in from a thread
+#: — must not be able to obtain in-tree trust by accident.
+_ACTIVE_TIER: ContextVar[DeclarationTier] = ContextVar(
+    "sparkrun_declaring_tier",
+    default=DeclarationTier.OUT_OF_TREE,
+)
+
+
+@contextmanager
+def declaring_tier(tier: DeclarationTier) -> Iterator[None]:
+    """Mark declarations made inside this block as coming from *tier*.
+
+    Used by the plugin loaders (:mod:`sparkrun.core.in_tree_plugins`,
+    :mod:`sparkrun.core.external_plugins`); plugins do not call this.
+    """
+    token = _ACTIVE_TIER.set(tier)
+    try:
+        yield
+    finally:
+        _ACTIVE_TIER.reset(token)
+
+
+@dataclass(frozen=True)
+class DeclaredRegistry:
+    """One registry a plugin declared, plus who declared it."""
+
+    entry: RegistryEntry
+    owner: str
+    tier: DeclarationTier
+
+    def effective_entry(self) -> RegistryEntry:
+        """A private copy of the entry, with trust resolved by tier.
+
+        An **in-tree** declaration may ship ``trusted=True``: it arrives through
+        the same review and release gate as the shipped defaults (and, when
+        vendored, through a pinned commit with per-file digests), so declaring
+        it trusted is the same act as adding a trusted entry to
+        ``FALLBACK_DEFAULT_REGISTRIES``.
+
+        An **out-of-tree** declaration is forced untrusted.  Installing a plugin
+        says "I want this capability"; it does not say "I grant its recipe repo
+        standing permission to run lifecycle hooks from whatever it contains
+        next month".  Those are separable, and the user grants the second
+        explicitly with ``sparkrun registry trust <name>`` — which materializes
+        the entry, so it sticks.
+
+        The copy matters: callers mutate what they are handed (``trust_registry``
+        flips ``trusted``, ``disable_registry`` flips ``enabled``), and this is
+        the only source of these entries, so aliasing would let one invocation
+        rewrite the declaration process-wide.
+        """
+        trusted = bool(self.entry.trusted) and self.tier is DeclarationTier.IN_TREE
+        if self.entry.trusted and not trusted:
+            logger.debug(
+                "Ignoring trusted=True on registry %r declared by out-of-tree plugin %r; run 'sparkrun registry trust %s' to grant it",
+                self.entry.name,
+                self.owner,
+                self.entry.name,
+            )
+        return _dataclass_replace(self.entry, trusted=trusted, declared_by=self.owner)
+
+
+#: name -> declaration.  Keyed by name because a name is what collides.
+_DECLARED: dict[str, DeclaredRegistry] = {}
+
+
+def register_default_registry(entry: RegistryEntry, *, owner: str) -> None:
+    """Declare a registry that should exist while *owner* is loaded.
+
+    Args:
+        entry: The registry to contribute.  ``enabled`` / ``visible`` / trusted
+            are honored subject to the tier rules above.
+        owner: The declaring plugin's name.  Required and non-blank.
+
+    Raises:
+        ValueError: If *owner* is blank.
+        RegistryError: If the name or a subpath is unsafe, the name impersonates
+            a reserved namespace, or a *different* owner already declared it.
+
+    Registration is idempotent for the same owner and an equal entry, so a
+    re-imported plugin module is harmless.  A second owner claiming the same
+    name raises — mirroring :func:`sparkrun.core.recipe_items.register_recipe_item`,
+    because two plugins silently reinterpreting one registry name has no correct
+    arbitration.
+
+    Validation runs **here**, at the declaration's own call site, rather than
+    where the overlay is applied — a plugin is local code we can fix, unlike a
+    hostile remote manifest that must be survived, so this raises instead of
+    dropping the entry.
+    """
+    if not owner or not owner.strip():
+        raise ValueError("plugin registry declaration requires a non-blank owner")
+
+    # Both guards are mandatory: a name becomes a directory under the cache root
+    # (and _link_registry_to_shared rmtree()s a non-link cache dir, making an
+    # escaping name a delete primitive), and a subpath becomes a path inside it
+    # whose contents are offered to the recipe loader.
+    validate_registry_name(entry.name, entry.url)
+    assert_safe_registry_entry(entry)
+
+    declaration = DeclaredRegistry(entry=entry, owner=owner, tier=_ACTIVE_TIER.get())
+
+    existing = _DECLARED.get(entry.name)
+    if existing is not None:
+        if existing.owner == owner and existing.entry == entry:
+            return
+        if existing.owner != owner:
+            raise RegistryError("registry %r is already declared by plugin %r" % (entry.name, existing.owner))
+    _DECLARED[entry.name] = declaration
+    logger.debug(
+        "Plugin %r declared %s registry %r -> %s",
+        owner,
+        declaration.tier.value,
+        entry.name,
+        entry.url,
+    )
+
+
+def iter_declared_registries() -> tuple[DeclaredRegistry, ...]:
+    """Every current declaration, ordered by owner then name.
+
+    Deterministic rather than insertion-ordered so the overlay a user sees does
+    not depend on plugin load order.
+    """
+    return tuple(sorted(_DECLARED.values(), key=lambda d: (d.owner, d.entry.name)))
+
+
+def declared_registry_names() -> frozenset[str]:
+    """Names currently declared by a plugin."""
+    return frozenset(_DECLARED)
+
+
+def reset_declared_registries() -> None:
+    """Drop every declaration.
+
+    Process-global state, so the test suite must reset it between tests exactly
+    as it resets the bootstrap ``_variables`` singleton — otherwise one test's
+    declaration leaks into every later test's registry list.
+    """
+    _DECLARED.clear()
+
+
+__all__ = [
+    "DeclarationTier",
+    "DeclaredRegistry",
+    "declared_registry_names",
+    "declaring_tier",
+    "iter_declared_registries",
+    "register_default_registry",
+    "reset_declared_registries",
+]

--- a/src/sparkrun/orchestration/distribution.py
+++ b/src/sparkrun/orchestration/distribution.py
@@ -35,6 +35,20 @@ class DistributionError(TransferError):
     """Raised when resource distribution (image or model sync) fails."""
 
 
+def _force_registry_pull_for_recipe(recipe: "Recipe") -> bool:
+    """Return whether ``rebuild`` means re-pull the resolved registry image.
+
+    Recipes without a builder, and recipes using the explicit ``docker-pull``
+    builder, delegate freshness to distribution.  Builders such as ColdSnap
+    and EUGR produce a new local image themselves; forcing a registry pull of
+    that derived name would discard the successful build and usually fail
+    because the image has not been published.
+    """
+    rebuild = bool(recipe.builder_config.get("rebuild")) if recipe.builder_config else False
+    builder = str(getattr(recipe, "builder", "") or "").strip()
+    return rebuild and builder in {"", "docker-pull"}
+
+
 @dataclass
 class TransferModeResult:
     """Result of :func:`resolve_auto_transfer_mode`.
@@ -804,7 +818,7 @@ def distribute_from_config(
     # which declares no builder at all and so never reaches the builder phase —
     # the equivalent is an unconditional `docker pull`.  Reading it here rather
     # than in the builder is what makes the flag reach those recipes.
-    _force_pull = bool(recipe.builder_config.get("rebuild")) if recipe.builder_config else False
+    _force_pull = _force_registry_pull_for_recipe(recipe)
     if _force_pull:
         logger.info("rebuild requested; forcing a fresh pull of image '%s'", image)
 

--- a/src/sparkrun/orchestration/sudo.py
+++ b/src/sparkrun/orchestration/sudo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from typing import Any
 
 from sparkrun.orchestration import ssh as _ssh
 from sparkrun.orchestration.ssh import RemoteResult
@@ -413,6 +414,7 @@ def ensure_remote_dir_ownership(
     ssh_options: list[str] | None = None,
     dry_run: bool = False,
     resource_label: str = "cache",
+    session: Any | None = None,
 ) -> list[str]:
     """Best-effort ``chown`` of *dir_path* to the SSH user on each host.
 
@@ -435,17 +437,30 @@ def ensure_remote_dir_ownership(
     # and tilde expansion does not happen inside the double quotes this script
     # interpolates into, so it has to become "$HOME/...".
     script = _FIX_OWNERSHIP_SCRIPT.format(path=safe_remote_path(dir_path))
-    results = _ssh.run_remote_scripts_parallel(
-        hosts,
-        script,
-        ssh_user=ssh_user,
-        ssh_key=ssh_key,
-        ssh_options=ssh_options,
-        timeout=60,
-        dry_run=dry_run,
-    )
-
-    failed = [r.host for r in results if not r.success]
+    if session is None:
+        results = _ssh.run_remote_scripts_parallel(
+            hosts,
+            script,
+            ssh_user=ssh_user,
+            ssh_key=ssh_key,
+            ssh_options=ssh_options,
+            timeout=60,
+            dry_run=dry_run,
+        )
+        failed = [result.host for result in results if not result.success]
+    elif dry_run:
+        failed = []
+    else:
+        failed = []
+        for host in hosts:
+            try:
+                result = session.execute(host, ["bash", "-c", script], timeout=60)
+            except Exception:
+                logger.debug("Could not repair %s ownership on %s", resource_label, host, exc_info=True)
+                failed.append(host)
+            else:
+                if result.returncode != 0:
+                    failed.append(host)
     if failed:
         logger.warning(
             "Could not fix %s ownership on %d host(s) (%s) — a root-owned "

--- a/src/sparkrun/plugins/__init__.py
+++ b/src/sparkrun/plugins/__init__.py
@@ -21,10 +21,14 @@ from sparkrun.core.recipe_items import (
     RecipeItemHandler,
     register_recipe_item,
 )
+from sparkrun.core.registry import RegistryEntry
+from sparkrun.core.registry_defaults import register_default_registry
 
 __all__ = [
     "FunctionalRecipeItemHandler",
     "RecipeItemHandler",
+    "RegistryEntry",
     "register_cli_command",
+    "register_default_registry",
     "register_recipe_item",
 ]

--- a/src/sparkrun/telemetry/util.py
+++ b/src/sparkrun/telemetry/util.py
@@ -175,8 +175,22 @@ def system_info() -> TelemetryEvent:
     }
 
 
+def registry_is_plugin_declared(entry) -> bool:
+    """Return whether a registry came from a plugin declaration, not the user."""
+    return bool(attr_string(entry, "declared_by"))
+
+
 def registry_is_default(entry) -> bool:
-    """Return whether a configured registry matches a built-in/default registry."""
+    """Return whether a configured registry matches a built-in/default registry.
+
+    A plugin-declared registry counts as default.  ``non_default_*`` means "the
+    user added a third-party registry", and a first-party plugin contributing
+    its own is not that — without this, enabling a shipped plugin would flip
+    ``has_non_default_registries`` and silently change the meaning of a metric
+    already in published series.  They are counted separately below instead.
+    """
+    if registry_is_plugin_declared(entry):
+        return True
     name = attr_string(entry, "name")
     url = attr_string(entry, "url")
     if name in _DEFAULT_REGISTRY_NAMES:
@@ -190,12 +204,14 @@ def registry_summary(registries: Sequence) -> TelemetryEvent:
     enabled = [entry for entry in registries if bool(getattr(entry, "enabled", True))]
     non_default = [entry for entry in registries if not registry_is_default(entry)]
     enabled_non_default = [entry for entry in enabled if not registry_is_default(entry)]
+    plugin_declared = [entry for entry in registries if registry_is_plugin_declared(entry)]
     return {
         "registry_count": total,
         "enabled_registry_count": len(enabled),
         "non_default_registry_count": len(non_default),
         "enabled_non_default_registry_count": len(enabled_non_default),
         "has_non_default_registries": bool(non_default),
+        "plugin_registry_count": len(plugin_declared),
     }
 
 

--- a/src/sparkrun/utils/cli_formatters.py
+++ b/src/sparkrun/utils/cli_formatters.py
@@ -575,13 +575,24 @@ def _wrap(text: str, width: int, indent: str) -> list[str]:
     )
 
 
-def format_launch_timings(export: dict, *, width: int = 62, title: str = "Launch timings") -> str:
+def format_launch_timings(
+    export: dict,
+    *,
+    width: int = 62,
+    title: str = "Launch timings",
+    max_depth: int | None = None,
+) -> str:
     """Render a :meth:`~sparkrun.core.timing.Timeline.export` as a tree.
 
     Spans nest by parent id rather than by name, because fan-out spans
     repeat their name (one per host / per distribution entry) and a
     name-keyed tree would collapse them into one row.
+
+    ``max_depth`` counts displayed levels starting at one for root spans.
+    Deeper descendants are omitted. ``None`` leaves the tree unbounded.
     """
+    if max_depth is not None and max_depth < 1:
+        raise ValueError("max_depth must be at least 1")
     spans = export.get("spans") or []
     if not spans:
         return ""
@@ -619,9 +630,14 @@ def format_launch_timings(export: dict, *, width: int = 62, title: str = "Launch
             clock = span.get("clock")
             if clock:
                 timing += "  [%s]" % clock
+            if attrs.get("composition") == "non_additive":
+                semantics = str(attrs.get("timing_semantics") or "aggregate").replace("_", " ")
+                timing += "  [%s; non-additive]" % semantics
             pad = max(1, width - len(indent) - len(label))
             lines.append("%s%s%s%s" % (indent, label, " " * pad, timing))
-            walk(span.get("id"), depth + 1)
+            displayed_depth = depth + 1
+            if max_depth is None or displayed_depth < max_depth:
+                walk(span.get("id"), depth + 1)
 
     walk(None, 0)
     return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,12 @@ def isolate_stateful(tmp_path: Path, monkeypatch):
     from sparkrun.models.hub import reset_hub_state
 
     reset_hub_state()
+    # Plugin-declared registries are a process-global overlay, so a test that
+    # declares one would otherwise add it to every later test's registry list --
+    # the same ordering-dependent failure class as the Hub state above.
+    from sparkrun.core.registry_defaults import reset_declared_registries
+
+    reset_declared_registries()
     # ...and block the send itself, because the env var above is only policy.
     # Any test can drop it (test_telemetry.py does, on purpose), and telemetry
     # fails *open*: a MagicMock config makes `telemetry_enabled` return True,

--- a/tests/test_api_run_eviction.py
+++ b/tests/test_api_run_eviction.py
@@ -209,6 +209,24 @@ def test_status_query_failure_is_swallowed(cluster):
         )
 
 
+def test_strict_status_query_failure_aborts(cluster):
+    with patch(
+        "sparkrun.orchestration.executor.query_status_for_cluster",
+        side_effect=RuntimeError("hosts unreachable"),
+    ):
+        with pytest.raises(RuntimeError, match="could not query cluster status"):
+            _evict_superseded_deployments(
+                intent_id=INTENT,
+                cluster_id_for_launch=NEW,
+                candidate_hosts=list(cluster.hosts),
+                target_hosts=list(cluster.hosts),
+                cluster_def=cluster,
+                config=None,
+                sctx=None,
+                strict=True,
+            )
+
+
 def test_stop_failure_is_swallowed(cluster):
     status = _status(("h1", [_workload(PRIOR, INTENT)]))
 
@@ -216,6 +234,26 @@ def test_stop_failure_is_swallowed(cluster):
 
     assert evicted == []
     assert len(calls) == 1  # attempted, then gave up on that deployment
+
+
+def test_strict_stop_failure_aborts(cluster):
+    status = _status(("h1", [_workload(PRIOR, INTENT)]))
+
+    with (
+        patch("sparkrun.orchestration.executor.query_status_for_cluster", return_value=status),
+        patch.object(api, "stop", side_effect=RuntimeError("ssh down")),
+    ):
+        with pytest.raises(RuntimeError, match="could not stop earlier deployment"):
+            _evict_superseded_deployments(
+                intent_id=INTENT,
+                cluster_id_for_launch=NEW,
+                candidate_hosts=list(cluster.hosts),
+                target_hosts=["h1"],
+                cluster_def=cluster,
+                config=None,
+                sctx=None,
+                strict=True,
+            )
 
 
 def test_unconfirmed_teardown_still_counts_as_attempted(cluster, caplog):
@@ -233,6 +271,26 @@ def test_unconfirmed_teardown_still_counts_as_attempted(cluster, caplog):
 
     assert evicted == [PRIOR]
     assert "did not confirm" in caplog.text
+
+
+def test_strict_unconfirmed_teardown_aborts(cluster):
+    status = _status(("h1", [_workload(PRIOR, INTENT)]))
+
+    with (
+        patch("sparkrun.orchestration.executor.query_status_for_cluster", return_value=status),
+        patch.object(api, "stop", return_value=_StopPartial(PRIOR, ["h1"])),
+    ):
+        with pytest.raises(RuntimeError, match="was not confirmed on h1"):
+            _evict_superseded_deployments(
+                intent_id=INTENT,
+                cluster_id_for_launch=NEW,
+                candidate_hosts=list(cluster.hosts),
+                target_hosts=["h1"],
+                cluster_def=cluster,
+                config=None,
+                sctx=None,
+                strict=True,
+            )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_cluster_manager.py
+++ b/tests/test_cluster_manager.py
@@ -22,6 +22,70 @@ def test_create_cluster(tmp_path: Path):
     assert cluster.description == "Test description"
 
 
+def test_cluster_sparkrun_cache_and_plugin_policy_round_trip_independently(tmp_path: Path):
+    from sparkrun.core.cluster_manager import ClusterDefinition
+
+    manager = ClusterManager(tmp_path)
+    manager._write_cluster(
+        ClusterDefinition(
+            name="storage-policy",
+            hosts=["host1", "host2"],
+            cache_dir="/mnt/shared/huggingface",
+            sparkrun_cache_dir="/mnt/local/sparkrun",
+            plugins={
+                "coldsnap": {
+                    "state_root": "/mnt/local/coldsnap",
+                    "io": {"recovery_read": "buffered"},
+                }
+            },
+        )
+    )
+
+    cluster = manager.get("storage-policy")
+    assert cluster.cache_dir == "/mnt/shared/huggingface"
+    assert cluster.sparkrun_cache_dir == "/mnt/local/sparkrun"
+    assert cluster.plugin_settings("coldsnap") == {
+        "state_root": "/mnt/local/coldsnap",
+        "io": {"recovery_read": "buffered"},
+    }
+    exported = cluster.to_dict()
+    assert exported["sparkrun_cache_dir"] == "/mnt/local/sparkrun"
+    assert exported["plugins"]["coldsnap"]["state_root"] == "/mnt/local/coldsnap"
+
+
+def test_cluster_create_and_update_preserve_sparkrun_cache_and_plugin_policy(tmp_path: Path):
+    manager = ClusterManager(tmp_path)
+    manager.create(
+        "managed-policy",
+        ["host1"],
+        sparkrun_cache_dir="/mnt/sparkrun-a",
+        plugins={"coldsnap": {"io": {"recovery_read": "buffered"}}},
+    )
+    created = manager.get("managed-policy")
+    assert created.sparkrun_cache_dir == "/mnt/sparkrun-a"
+    assert created.plugin_settings("coldsnap")["io"]["recovery_read"] == "buffered"
+
+    manager.update(
+        "managed-policy",
+        sparkrun_cache_dir="/mnt/sparkrun-b",
+        plugins={"coldsnap": {"state_root": "/mnt/coldsnap"}},
+    )
+    updated = manager.get("managed-policy")
+    assert updated.sparkrun_cache_dir == "/mnt/sparkrun-b"
+    assert updated.plugin_settings("coldsnap") == {"state_root": "/mnt/coldsnap"}
+
+
+def test_cluster_plugin_policy_rejects_plugin_discovery_paths(tmp_path: Path):
+    root = tmp_path / "clusters"
+    root.mkdir()
+    (root / "invalid.yaml").write_text(
+        "name: invalid\nhosts: [host1]\nplugins:\n  coldsnap:\n    paths: [/tmp/plugin]\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ClusterError, match="cannot declare plugin discovery paths"):
+        ClusterManager(tmp_path).get("invalid")
+
+
 def test_create_cluster_already_exists(tmp_path: Path):
     """Creating a cluster with an existing name raises ClusterError."""
     manager = ClusterManager(tmp_path)

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -329,6 +329,25 @@ def test_progress_heartbeat_stops_at_exit(caplog):
     assert len(caplog.records) == emitted
 
 
+def test_progress_heartbeat_uses_dynamic_label(caplog):
+    """Callers can make heartbeat detail follow live operation state."""
+    import logging
+    import time
+
+    from sparkrun.core.progress import PROGRESS, progress_heartbeat
+
+    detail = {"value": "Preparing capsules"}
+    logger = logging.getLogger("sparkrun.test.heartbeat.dynamic")
+    with (
+        caplog.at_level(PROGRESS, logger="sparkrun.test.heartbeat.dynamic"),
+        progress_heartbeat(logger, lambda: detail["value"], interval=0.02),
+    ):
+        detail["value"] = "Pulling capsules on 2 nodes"
+        time.sleep(0.05)
+
+    assert "Pulling capsules on 2 nodes — still running" in caplog.text
+
+
 def test_progress_heartbeat_propagates_the_failure_it_was_watching():
     """The heartbeat is observational: it never swallows the work's error."""
     import logging

--- a/tests/test_rebuild_force_pull.py
+++ b/tests/test_rebuild_force_pull.py
@@ -267,20 +267,24 @@ class TestRebuildDerivedFromRecipe:
     """``--rebuild`` reaches distribution as ``builder_config.rebuild``."""
 
     @pytest.mark.parametrize(
-        "builder_config,expected",
+        "builder,builder_config,expected",
         [
-            ({"rebuild": True}, True),
-            ({"rebuild": False}, False),
-            ({}, False),
-            (None, False),
+            ("", {"rebuild": True}, True),
+            ("docker-pull", {"rebuild": True}, True),
+            ("coldsnap", {"rebuild": True}, False),
+            ("eugr", {"rebuild": True}, False),
+            ("", {"rebuild": False}, False),
+            ("", {}, False),
+            ("", None, False),
         ],
     )
-    def test_derivation(self, builder_config, expected):
-        # Mirrors the expression in distribute_from_config; kept as a unit so a
-        # change to the truthiness rule (e.g. a None-vs-absent distinction) is
-        # caught without standing up the whole distribution path.
-        force_pull = bool(builder_config.get("rebuild")) if builder_config else False
-        assert force_pull is expected
+    def test_derivation(self, builder, builder_config, expected):
+        from types import SimpleNamespace
+
+        from sparkrun.orchestration.distribution import _force_registry_pull_for_recipe
+
+        recipe = SimpleNamespace(builder=builder, builder_config=builder_config)
+        assert _force_registry_pull_for_recipe(recipe) is expected
 
     def test_cli_rebuild_flag_lands_on_builder_config(self):
         """The CLI writes the flag the distribution layer reads."""

--- a/tests/test_registry_defaults.py
+++ b/tests/test_registry_defaults.py
@@ -1,0 +1,339 @@
+"""Tests for plugin-declared default registries (``core.registry_defaults``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from sparkrun.core.registry import (
+    FALLBACK_DEFAULT_REGISTRIES,
+    SUPPRESSED_REGISTRIES_KEY,
+    RegistryEntry,
+    RegistryError,
+    RegistryManager,
+)
+from sparkrun.core.registry_defaults import (
+    DeclarationTier,
+    declaring_tier,
+    iter_declared_registries,
+    register_default_registry,
+    reset_declared_registries,
+)
+
+import yaml
+
+PLUGIN_URL = "https://github.com/sparksq/sparkrun-recipes.git"
+
+
+def _entry(name: str = "coldsnap", **kw) -> RegistryEntry:
+    fields = {"name": name, "url": PLUGIN_URL, "subpath": "coldsnap-recipes"}
+    fields.update(kw)
+    return RegistryEntry(**fields)
+
+
+@pytest.fixture
+def mgr(tmp_path) -> RegistryManager:
+    return RegistryManager(config_root=tmp_path / "config", cache_root=tmp_path / "cache")
+
+
+def _read_yaml(mgr: RegistryManager) -> dict:
+    return yaml.safe_load(mgr._registries_path.read_text()) or {}
+
+
+# --------------------------------------------------------------------------
+# Registration
+# --------------------------------------------------------------------------
+
+
+def test_declaration_requires_a_non_blank_owner():
+    with pytest.raises(ValueError):
+        register_default_registry(_entry(), owner="   ")
+
+
+def test_declaration_is_idempotent_for_the_same_owner_and_entry():
+    register_default_registry(_entry(), owner="coldsnap")
+    register_default_registry(_entry(), owner="coldsnap")
+    assert len(iter_declared_registries()) == 1
+
+
+def test_a_second_owner_cannot_claim_an_existing_name():
+    register_default_registry(_entry(), owner="coldsnap")
+    with pytest.raises(RegistryError, match="already declared by plugin 'coldsnap'"):
+        register_default_registry(_entry(), owner="impostor")
+
+
+def test_the_same_owner_may_revise_its_own_declaration():
+    register_default_registry(_entry(), owner="coldsnap")
+    register_default_registry(_entry(description="revised"), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    assert declared.entry.description == "revised"
+
+
+def test_an_unsafe_name_is_rejected():
+    with pytest.raises(RegistryError):
+        register_default_registry(_entry(name="../escape"), owner="coldsnap")
+
+
+def test_an_unsafe_subpath_is_rejected():
+    with pytest.raises(RegistryError):
+        register_default_registry(_entry(subpath="../../etc"), owner="coldsnap")
+
+
+def test_a_reserved_name_from_the_wrong_org_is_rejected():
+    """`coldsnap` is reserved to sparksq; another org may not declare it."""
+    with pytest.raises(RegistryError, match="reserved"):
+        register_default_registry(
+            _entry(url="https://github.com/somebody-else/recipes.git"),
+            owner="impostor",
+        )
+
+
+def test_the_reserved_name_is_accepted_from_its_own_org():
+    register_default_registry(_entry(), owner="coldsnap")
+    assert [d.entry.name for d in iter_declared_registries()] == ["coldsnap"]
+
+
+def test_reserved_names_admit_the_urls_coldsnap_declares():
+    """Guards the §4 failure mode: a mismatch makes the plugin raise at bootstrap."""
+    from sparkrun.core.registry import EXTERNAL_RESERVED_NAMES, _get_git_org
+
+    org = _get_git_org(PLUGIN_URL)
+    assert org == "sparksq"
+    for name in ("coldsnap", "coldsnap-vanilla"):
+        assert org in EXTERNAL_RESERVED_NAMES[name]
+
+
+def test_declarations_are_ordered_deterministically():
+    register_default_registry(_entry("coldsnap-vanilla", subpath="vanilla-recipes"), owner="coldsnap")
+    register_default_registry(_entry("coldsnap"), owner="coldsnap")
+    assert [d.entry.name for d in iter_declared_registries()] == ["coldsnap", "coldsnap-vanilla"]
+
+
+# --------------------------------------------------------------------------
+# Tier / trust
+# --------------------------------------------------------------------------
+
+
+def test_in_tree_declarations_may_ship_trusted():
+    with declaring_tier(DeclarationTier.IN_TREE):
+        register_default_registry(_entry(trusted=True), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    assert declared.effective_entry().trusted is True
+
+
+def test_out_of_tree_declarations_are_forced_untrusted():
+    with declaring_tier(DeclarationTier.OUT_OF_TREE):
+        register_default_registry(_entry(trusted=True), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    assert declared.effective_entry().trusted is False
+
+
+def test_the_default_tier_is_the_unprivileged_one():
+    """A declaration made outside any loader must not acquire in-tree trust."""
+    register_default_registry(_entry(trusted=True), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    assert declared.tier is DeclarationTier.OUT_OF_TREE
+    assert declared.effective_entry().trusted is False
+
+
+def test_effective_entry_does_not_alias_the_declaration():
+    with declaring_tier(DeclarationTier.IN_TREE):
+        register_default_registry(_entry(), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    first = declared.effective_entry()
+    first.enabled = False
+    assert declared.effective_entry().enabled is True
+
+
+def test_the_loader_supplies_the_tier(monkeypatch):
+    """load_plugin_module wraps registration; the plugin never states its tier."""
+    import types
+
+    from sparkrun.core.external_plugins import load_plugin_module
+
+    module = types.ModuleType("fake_in_tree_plugin")
+    module.register = lambda v: register_default_registry(_entry(trusted=True), owner="coldsnap")
+    monkeypatch.setattr("sparkrun.core.external_plugins._plugin_base_types", lambda: [])
+
+    load_plugin_module(module, None, tier=DeclarationTier.IN_TREE)
+    (declared,) = iter_declared_registries()
+    assert declared.tier is DeclarationTier.IN_TREE
+    assert declared.effective_entry().trusted is True
+
+
+def test_the_tier_does_not_leak_past_a_load(monkeypatch):
+    import types
+
+    from sparkrun.core.external_plugins import load_plugin_module
+
+    module = types.ModuleType("fake_plugin")
+    module.register = lambda v: None
+    monkeypatch.setattr("sparkrun.core.external_plugins._plugin_base_types", lambda: [])
+    load_plugin_module(module, None, tier=DeclarationTier.IN_TREE)
+
+    register_default_registry(_entry(trusted=True), owner="later")
+    (declared,) = iter_declared_registries()
+    assert declared.tier is DeclarationTier.OUT_OF_TREE
+
+
+# --------------------------------------------------------------------------
+# Overlay
+# --------------------------------------------------------------------------
+
+
+def test_the_overlay_appears_on_a_fresh_install(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    assert "coldsnap" in {r.name for r in mgr.list_registries()}
+
+
+def _materialize_config(mgr: RegistryManager) -> None:
+    """Force registries.yaml into existence.
+
+    ``_default_registries`` only persists when manifest discovery found
+    something, and the hermetic suite empties ``BOOTSTRAP_REGISTRY_URLS`` — so a
+    plain ``list_registries()`` leaves no file. Any mutation writes one.
+    """
+    mgr.add_registry(RegistryEntry(name="seed", url="https://github.com/me/seed.git", subpath="r"))
+    assert mgr._registries_path.exists()
+
+
+def test_the_overlay_appears_on_an_existing_install(mgr):
+    _materialize_config(mgr)
+
+    register_default_registry(_entry(), owner="coldsnap")
+    entry = next(r for r in mgr.list_registries() if r.name == "coldsnap")
+    assert entry.declared_by == "coldsnap"
+
+
+def test_the_overlay_is_never_persisted(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.list_registries()
+    mgr.disable_registry("official")  # force a save of an unrelated entry
+
+    names = {r["name"] for r in _read_yaml(mgr)["registries"]}
+    assert "coldsnap" not in names
+
+
+def test_withdrawing_a_declaration_removes_the_entry(mgr):
+    _materialize_config(mgr)
+    register_default_registry(_entry(), owner="coldsnap")
+    assert "coldsnap" in {r.name for r in mgr.list_registries()}
+
+    reset_declared_registries()
+    assert "coldsnap" not in {r.name for r in mgr.list_registries()}
+    assert "coldsnap" not in {r["name"] for r in _read_yaml(mgr)["registries"]}
+
+
+def test_a_file_entry_of_the_same_name_wins(mgr):
+    mgr.add_registry(_entry(url="https://github.com/sparksq/sparkrun-recipes.git", subpath="mine"))
+    register_default_registry(_entry(subpath="coldsnap-recipes"), owner="coldsnap")
+
+    entry = next(r for r in mgr.list_registries() if r.name == "coldsnap")
+    assert entry.subpath == "mine"
+    assert entry.declared_by == ""
+
+
+def test_a_declaration_cannot_shadow_a_shipped_default(mgr, caplog):
+    shipped = FALLBACK_DEFAULT_REGISTRIES[0]
+    register_default_registry(
+        RegistryEntry(name=shipped.name, url="https://github.com/scitrera/other.git", subpath="r"),
+        owner="impostor",
+    )
+    with caplog.at_level("WARNING"):
+        entries = mgr.list_registries()
+
+    entry = next(r for r in entries if r.name == shipped.name)
+    assert entry.declared_by == ""
+    assert entry.url == shipped.url
+    assert "shipped default" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# Materialize on mutation / tombstones
+# --------------------------------------------------------------------------
+
+
+def test_disable_materializes_the_entry(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.disable_registry("coldsnap")
+
+    saved = {r["name"]: r for r in _read_yaml(mgr)["registries"]}
+    assert saved["coldsnap"]["enabled"] is False
+    assert mgr.get_registry("coldsnap").declared_by == ""
+
+
+def test_a_materialized_entry_survives_the_declaration_being_withdrawn(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.disable_registry("coldsnap")
+    reset_declared_registries()
+
+    entry = mgr.get_registry("coldsnap")
+    assert entry.enabled is False
+    assert entry.declared_by == ""
+
+
+def test_trust_materializes_and_sticks(mgr):
+    with declaring_tier(DeclarationTier.OUT_OF_TREE):
+        register_default_registry(_entry(trusted=True), owner="coldsnap")
+    assert mgr.get_registry("coldsnap").trusted is False  # forced untrusted by tier
+
+    mgr.trust_registry("coldsnap")
+    assert mgr.get_registry("coldsnap").trusted is True
+    assert {r["name"]: r for r in _read_yaml(mgr)["registries"]}["coldsnap"]["trusted"] is True
+
+
+def test_remove_tombstones_a_declared_registry(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.remove_registry("coldsnap")
+
+    assert _read_yaml(mgr)[SUPPRESSED_REGISTRIES_KEY] == ["coldsnap"]
+    assert "coldsnap" not in {r.name for r in mgr.list_registries()}
+
+
+def test_a_tombstone_survives_a_reload_with_the_declaration_present(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.remove_registry("coldsnap")
+
+    fresh = RegistryManager(config_root=mgr.config_root, cache_root=mgr.cache_root)
+    assert "coldsnap" not in {r.name for r in fresh.list_registries()}
+
+
+def test_re_adding_clears_the_tombstone(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.remove_registry("coldsnap")
+    mgr.add_registry(_entry(subpath="mine"))
+
+    assert SUPPRESSED_REGISTRIES_KEY not in _read_yaml(mgr)
+    assert mgr.get_registry("coldsnap").subpath == "mine"
+
+
+def test_removing_an_ordinary_registry_writes_no_tombstone(mgr):
+    mgr.add_registry(RegistryEntry(name="mine", url="https://github.com/me/r.git", subpath="r"))
+    mgr.remove_registry("mine")
+
+    assert SUPPRESSED_REGISTRIES_KEY not in _read_yaml(mgr)
+
+
+def test_removing_an_absent_registry_still_raises(mgr):
+    with pytest.raises(RegistryError, match="not found"):
+        mgr.remove_registry("nope")
+
+
+# --------------------------------------------------------------------------
+# Telemetry
+# --------------------------------------------------------------------------
+
+
+def test_a_declared_registry_is_not_counted_as_third_party():
+    from sparkrun.telemetry.util import registry_summary
+
+    declared = RegistryEntry(name="coldsnap", url=PLUGIN_URL, subpath="r", declared_by="coldsnap")
+    user_added = RegistryEntry(name="mine", url="https://github.com/me/r.git", subpath="r")
+
+    summary = registry_summary([declared, user_added])
+    assert summary["plugin_registry_count"] == 1
+    assert summary["non_default_registry_count"] == 1  # only the user's own
+    assert summary["has_non_default_registries"] is True
+
+    only_declared = registry_summary([declared])
+    assert only_declared["has_non_default_registries"] is False
+    assert only_declared["plugin_registry_count"] == 1

--- a/tests/test_run_timings_readiness.py
+++ b/tests/test_run_timings_readiness.py
@@ -41,6 +41,23 @@ from sparkrun.core.launcher import ReadinessWatcher, ServeReadiness, wait_for_en
 from sparkrun.core.timing import Timeline
 from sparkrun.orchestration.health import wait_for_healthy, wait_for_port
 
+
+@pytest.mark.parametrize(
+    ("verbosity", "expected"),
+    [(0, 2), (1, 3), (2, 4), (3, None), (4, None), (-1, 2)],
+)
+def test_run_timing_tree_depth_tracks_global_verbosity(verbosity, expected):
+    from sparkrun.cli._run import _timing_tree_depth
+
+    class Context:
+        obj = {"verbose": verbosity}
+
+        def find_root(self):
+            return self
+
+    assert _timing_tree_depth(Context()) == expected
+
+
 # ---------------------------------------------------------------------------
 # Cancellation in the underlying waiters
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -10,6 +10,8 @@ See ``.slop/runtime-cache-design.md``.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from sparkrun.core.recipe import Recipe
@@ -365,6 +367,23 @@ def test_explicit_dir_setting_wins_over_the_probed_root():
 
 def test_root_defaults_under_the_sparkrun_cache_dir():
     assert resolve_runtime_cache_root(RuntimeCacheSettings(), "/home/u/.cache/sparkrun") == "/home/u/.cache/sparkrun/runtime-cache"
+
+
+def test_effective_runtime_cache_dir_prefers_cluster_sparkrun_root():
+    from sparkrun.core.launcher import resolve_effective_runtime_cache_dir
+
+    cluster = SimpleNamespace(sparkrun_cache_dir="/mnt/local/sparkrun")
+    config = SimpleNamespace(cache_dir="/control/cache")
+    assert (
+        resolve_effective_runtime_cache_dir(
+            ["host1"],
+            {},
+            config,
+            dry_run=True,
+            cluster=cluster,
+        )
+        == "/mnt/local/sparkrun"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sudo.py
+++ b/tests/test_sudo.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import pytest
 from unittest.mock import patch
 
-from sparkrun.orchestration.sudo import run_indirect_sudo_script, run_sudo_script_on_host
+from sparkrun.orchestration.sudo import ensure_remote_dir_ownership, run_indirect_sudo_script, run_sudo_script_on_host
 from sparkrun.orchestration.ssh import RemoteResult
+from sparkrun.transports.session import HostCommandResult
 
 
 @patch("sparkrun.orchestration.ssh._run_subprocess")
@@ -125,3 +126,25 @@ def test_local_host_accepts_none_password(mock_run):
     assert res.host == "localhost"
     assert mock_run.call_args[0][0] == ["sudo", "-n", "bash", "-s"]
     assert mock_run.call_args[1]["input"] == "apt update"
+
+
+def test_ownership_repair_can_use_manager_host_session():
+    class Session:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, host, arguments, **kwargs):
+            self.calls.append((host, arguments, kwargs))
+            return HostCommandResult(host, 0 if host == "h1" else 1)
+
+    session = Session()
+    failed = ensure_remote_dir_ownership(
+        "/home/u/.cache/sparkrun",
+        ["h1", "h2"],
+        resource_label="ColdSnap cache",
+        session=session,
+    )
+
+    assert failed == ["h2"]
+    assert [call[0] for call in session.calls] == ["h1", "h2"]
+    assert all(call[1][:2] == ["bash", "-c"] for call in session.calls)

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -328,3 +328,30 @@ def test_formatter_accepts_operation_specific_title():
 
     rendered = format_launch_timings(tl.export(), title="Capture timings")
     assert rendered.startswith("Capture timings")
+
+
+def test_formatter_limits_displayed_tree_depth():
+    from sparkrun.utils.cli_formatters import format_launch_timings
+
+    tl = Timeline()
+    with tl.span("level-1"):
+        with tl.span("level-2"):
+            with tl.span("level-3"):
+                with tl.span("level-4"):
+                    pass
+
+    rendered = format_launch_timings(tl.export(), max_depth=2)
+    assert "level-1" in rendered
+    assert "level-2" in rendered
+    assert "level-3" not in rendered
+    assert "level-4" not in rendered
+
+    unbounded = format_launch_timings(tl.export())
+    assert "level-4" in unbounded
+
+
+def test_formatter_rejects_invalid_tree_depth():
+    from sparkrun.utils.cli_formatters import format_launch_timings
+
+    with pytest.raises(ValueError, match="max_depth"):
+        format_launch_timings({"spans": [{}]}, max_depth=0)


### PR DESCRIPTION
This pull request introduces several enhancements and new features to plugin-declared registries, cluster configuration, and command-line interface (CLI) usability in Sparkrun. The most significant changes are the addition of a robust mechanism for plugins to declare recipe registries (with clear documentation and user-facing feedback), the introduction of cluster-local plugin settings and configuration for the dedicated Sparkrun cache directory, and improvements to deployment eviction and CLI output for better user experience and safety.

**Plugin-Declared Registries:**

- Added support for plugins to declare their own recipe registries using `register_default_registry`, with detailed documentation and rationale in `docs/PLUGINS.md` and `CLAUDE.md`. Plugin-declared registries are overlays, not persistent config edits, and are removed automatically when the plugin is disabled or uninstalled. User actions on these registries (disable, trust, remove) are now clearly handled and surfaced in the CLI. [[1]](diffhunk://#diff-a4b5186ca4937b26e09acd667292cfaf1bb5f74fa05c3657eb70e8e42787964cR143-R210) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1966-R2012)

- The CLI now displays the provenance ("Source") of each registry in `sparkrun registry list` and `sparkrun registry show`, making it clear when a registry comes from a plugin and who declared it. Removal of a plugin-declared registry gives a clear, actionable message. [[1]](diffhunk://#diff-bfc5422c94cebf8b627331ebf2540241824a667a2caece6db1b250e88bc1a66aR69-R72) [[2]](diffhunk://#diff-bfc5422c94cebf8b627331ebf2540241824a667a2caece6db1b250e88bc1a66aR85-R87) [[3]](diffhunk://#diff-bfc5422c94cebf8b627331ebf2540241824a667a2caece6db1b250e88bc1a66aR103-R105) [[4]](diffhunk://#diff-bfc5422c94cebf8b627331ebf2540241824a667a2caece6db1b250e88bc1a66aR215-R231) [[5]](diffhunk://#diff-bfc5422c94cebf8b627331ebf2540241824a667a2caece6db1b250e88bc1a66aR329-R330)

**Cluster Configuration Enhancements:**

- Added `sparkrun_cache_dir` and `plugins` fields to `ClusterDefinition`, allowing for a remote cluster-specific Sparkrun state/cache root and cluster-local plugin settings. These are validated, serialized, and exposed via a new `plugin_settings` method, and are handled in cluster creation and update flows. [[1]](diffhunk://#diff-7bfb97ef0e1c2257c84b583096081d7147bc972d5fb15106dedcc8e96320f8dcR201-R209) [[2]](diffhunk://#diff-7bfb97ef0e1c2257c84b583096081d7147bc972d5fb15106dedcc8e96320f8dcR394-R414) [[3]](diffhunk://#diff-7bfb97ef0e1c2257c84b583096081d7147bc972d5fb15106dedcc8e96320f8dcR612-R613) [[4]](diffhunk://#diff-7bfb97ef0e1c2257c84b583096081d7147bc972d5fb15106dedcc8e96320f8dcR623-R624) [[5]](diffhunk://#diff-7bfb97ef0e1c2257c84b583096081d7147bc972d5fb15106dedcc8e96320f8dcR663-R664) [[6]](diffhunk://#diff-7bfb97ef0e1c2257c84b583096081d7147bc972d5fb15106dedcc8e96320f8dcR682-R683) [[7]](diffhunk://#diff-7bfb97ef0e1c2257c84b583096081d7147bc972d5fb15106dedcc8e96320f8dcR726-R727)

**Deployment and CLI Usability Improvements:**

- Enhanced `_evict_superseded_deployments` to support a `strict` mode: when enabled, any failure to discover or tear down previous deployments will abort the launch, preventing resource collisions. By default, errors remain best-effort and non-blocking. [[1]](diffhunk://#diff-59382b16dacd96a42535fd5addcc94bd21a5e99badf9676e94bacee84535694dR655) [[2]](diffhunk://#diff-59382b16dacd96a42535fd5addcc94bd21a5e99badf9676e94bacee84535694dL685-R690) [[3]](diffhunk://#diff-59382b16dacd96a42535fd5addcc94bd21a5e99badf9676e94bacee84535694dR714-R715) [[4]](diffhunk://#diff-59382b16dacd96a42535fd5addcc94bd21a5e99badf9676e94bacee84535694dR749-R755)

- Improved timing output in `run` command: the detail level of launch timings now adapts to the global verbosity flag, providing more relevant information based on user preference. [[1]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08R73-R80) [[2]](diffhunk://#diff-8a83264bf3476996ef0367ca0954d86bb06f043c3dc8d68b40071f1106fecf08L943-R951)