### PR TITLE
Promote v0.3.7 Alpha to Beta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1817,6 +1817,21 @@ Catalogue notes worth knowing before adding a check:
   `--dry-run` (the command you review is not the one that runs), for pre-placed
   weights, and when the GGUF was not pre-synced here. Warning, not error: a
   requirement sparkrun's resolution cannot express is a reason to keep the key.
+- **`deprecated-recipe-name` is a deprecation for something already inert.**
+  `name:` is the v1 spelling; `Recipe.__init__` assigns the filename stem
+  unconditionally (the `data.get("name", …)` beside it is commented out), so a
+  declared name is *discarded on load* rather than merely scheduled to stop
+  working — which is worth saying plainly, since a recipe that names itself one
+  thing and resolves as another is only visible by listing it. It must read
+  `_raw` (the parsed attribute is never the declared value — the `mode:` trap)
+  via `getattr`, since `__setstate__` does not restore `_raw` and a recipe
+  revived from the registry cache has no attribute at all. Gated on **not** v1,
+  the same way the brace escape is: every v1 recipe in the cached corpus
+  declares one and already carries `deprecated-recipe-format`, whose migration
+  subsumes it; three v2 recipes declare one, which is the population this is
+  for. Note the test fixtures had to drop `name:` too — `conftest`'s v2
+  samples and `test_cli`'s carried it, which is how widely the v1 idiom had
+  spread.
 - **`inline-script` names tools, never shape.** A recipe carrying a program —
   a heredoc'd patch script, `sed -i` over the installed package, a launch-time
   `pip install` — is doing what `mods:` exists for, and the argument is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1963,6 +1963,53 @@ user has. `SUBPATH_FIELDS` is the list any new path-forming field must join, or 
 lists registries, `@registry/` lists recipes from that registry. Falls back to showing registry names when recipe cache
 isn't populated.
 
+### Plugin-Declared Registries (`core/registry_defaults.py`)
+
+`BOOTSTRAP_REGISTRY_URLS` / `FALLBACK_DEFAULT_REGISTRIES` are closed constants. `register_default_registry(entry,
+owner=…)` is the extension point beside them, for a plugin whose recipes are **inert without it** — its registry
+resolves (`@coldsnap/<recipe>`) for anyone with the plugin enabled, with nothing to `registry add`. In-process (the
+`platforms` / `register_kv_strategy` precedent), re-exported from `sparkrun.plugins`, called from `register(v)`.
+Author-facing docs: `docs/PLUGINS.md`; full rationale: `.slop/plugin-declared-registries-design.md`.
+
+Six properties are load-bearing:
+
+- **Registration does no I/O.** `init_sparkrun` runs on *every* shell completion (Click resolves the command tree
+  through `PluggableGroup.get_command`; measured ~30 ms stock against a 92 ms unavoidable `import sparkrun.cli`), so
+  anything expensive lands on the interactive path. This is also why a plugin cannot source its *names* from a remote
+  `.sparkrun/registry.yaml` — the overlay must be computable offline. Declare in code; the repo manifest stays for
+  users adding the registry by URL.
+- **An overlay, never persisted.** `_apply_plugin_overlay` runs **last** in `_load_registries` / `_default_registries`,
+  after every convergent rewrite and any save, so declared entries never reach the migration or persistence path.
+  `_save_registries` additionally skips anything with `declared_by` set — every mutating command reads through
+  `_load_registries` and rewrites the whole document, so without that filter the first `registry disable` of anything
+  would quietly persist every declared registry and they would outlive their plugin. Uninstalling is therefore free:
+  declaration gone, entry gone, nothing to reap.
+- **Materialize on mutation.** `enable`/`disable`/`trust`/`untrust` call `_materialize_declared`, which *clears*
+  `declared_by` — that is what lets the entry through `_save_registries`, and from then on the file wins. `remove`
+  writes a **tombstone** (`suppressed_plugin_registries`) instead of deleting, because there is nothing in
+  `registries.yaml` to delete and dropping it in memory would let the declaration restore it next launch — a removal
+  that silently fails to remove. `add_registry` clears the tombstone.
+- **Trust is tiered by provenance, and the tier comes from the loader.** In-tree may ship `trusted=True` (same review
+  and release gate as the shipped defaults; for a vendored plugin, a pinned commit with per-file digests); out-of-tree
+  is forced `False` — installing a plugin says "I want this capability", not "I grant its recipe repo standing
+  hook-execution rights over whatever it contains next month". `load_plugin_module(…, tier=…)` sets a **contextvar**
+  around the load rather than taking an argument, because the *plugin* makes the registration call; the default is
+  `OUT_OF_TREE` (least privilege), so a declaration made outside any loader cannot acquire in-tree trust.
+- **Collisions are refused and warned, not ranked.** A declaration colliding with a shipped default is rejected with a
+  warning naming the owner — checked **before** the file-entry rule, since a shipped default is normally present in the
+  file and the reverse order would silently ignore a plugin trying to redefine `official`. Ranking would permit a
+  namespace redirect that `validate_registry_name` cannot catch (it only guards *reserved* names). The user's own file
+  entry is the one true override.
+- **Validation raises at the declaration's call site** (`validate_registry_name` + `assert_safe_registry_entry`) rather
+  than dropping the entry where the overlay is applied: a plugin is local code we can fix, unlike a hostile remote
+  manifest that must be survived. Note `validate_registry_name` checks the **registry URL's** org, not the plugin
+  repo's — `EXTERNAL_RESERVED_NAMES` reserves `coldsnap` / `coldsnap-vanilla` to `sparksq`. Reservation stays in core
+  so a plugin cannot reserve its own namespace.
+
+Telemetry counts declared registries as `plugin_registry_count` and excludes them from `non_default_*` — a first-party
+plugin contributing its own registry is not "the user added a third party", and counting it as such would silently
+change a metric already in published series.
+
 ### Recipe Catalog ("what recipes exist?")
 
 All recipe *enumeration* flows through one function, **`api.search_recipes(query, …) -> list[RecipeSummary]`**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1791,6 +1791,76 @@ Catalogue notes worth knowing before adding a check:
   (`XDG_CACHE_HOME`) is merged **first** so a recipe setting it *wins* and the
   compile caches land off the mount (`managed-cache-env`). Same-looking
   mistake, opposite outcome, opposite advice.
+- **`hardcoded-serve-flag` and `restated-model-arg` are mirror images.** The
+  first is about values sparkrun *reads* from the config chain, the second
+  about values it *writes* into the command. Both are suggestions for the same
+  reason — the rendered command serves exactly what it says, identically
+  everywhere — but the mechanisms defeated differ, so the advice does too.
+  `recipe.model` is rewritten mid-launch by three mechanisms that all reach the
+  command only through `{model}`: `resolved_model_path` (which also sets
+  `_skip_model_distribution`), an absolute `model:`, and a pre-synced GGUF
+  (whose raw value still carries the `:quant` suffix no runtime parses). None
+  is the author's to control. Measured: 39 of the 118 cached registry recipes
+  with a `command:` restate the id, and the id appears **nowhere else** in any
+  of them — which is why matching is whole-token and never substring.
+- **`restated-managed-path` reads `command:`, the hook lists and `defaults:`
+  values, but deliberately not `env:`.** `env` already has two dedicated checks
+  whose subject is a recipe touching sparkrun's cache wiring; a third message
+  about the same assignment is the noise this catalogue exists to avoid.
+  `_`-prefixed defaults are excluded for the same reason —
+  `internal-config-key` owns that line and says strictly more.
+- **`internal-config-key` fills a hole `_is_internal_config_key` left.** That
+  helper excludes `_`-prefixed keys from the unmapped-key report — correctly,
+  since they *are* consumed — which left a recipe **declaring** one
+  (`_gguf_model_path`, `_mmproj_path`) with no diagnostic at all. The injected
+  value outranks `defaults`, so the literal is normally dead; it wins under
+  `--dry-run` (the command you review is not the one that runs), for pre-placed
+  weights, and when the GGUF was not pre-synced here. Warning, not error: a
+  requirement sparkrun's resolution cannot express is a reason to keep the key.
+- **`inline-script` names tools, never shape.** A recipe carrying a program —
+  a heredoc'd patch script, `sed -i` over the installed package, a launch-time
+  `pip install` — is doing what `mods:` exists for, and the argument is
+  sparkrun-specific rather than stylistic: the three homes render differently
+  and only one leaves the script alone. `command:` goes through
+  `render_command`, whose escape mode is inferred *from the template*
+  (`uses_brace_escapes`), so an embedded program must double every literal
+  brace and drags the whole template into v1 escape mode — one missed brace
+  mis-renders it silently. A `pre_exec` string goes through
+  `render_hook_command`, which does not collapse `{{` but still substitutes
+  `{name}`, so a program is exposed to a collision with any config key it
+  spells. A mod's `run.sh` is `docker cp`'d verbatim and never rendered. Shape
+  is deliberately *not* a signal: the corpus clusters at 10–19 command lines
+  with nothing over 40, so a line-count threshold would report the recipes with
+  the most flags rather than the ones carrying code. Every signal measures zero
+  across the corpus except `pip install` (2 recipes), which is why the check
+  can afford to be broad. Suggestion, because an inline patch runs identically
+  everywhere — what is lost is reviewability, not portability. It reads
+  `defaults:` values too (a default reaches the command through its
+  placeholder, so a program can be written one remove away), but with
+  `site-packages` withheld there: every other signal names a *verb*, which is
+  unambiguous wherever it appears, while that one names a *location* — the
+  target of a write in a command, but as likely a plain path in
+  `defaults.chat_template`.
+- **`hardcoded-rendezvous-flag`'s flag list is the runtime's own**
+  (`RuntimePlugin.managed_rendezvous_flags`), with **no shared core** even
+  where two runtimes spell a flag identically. Which flags coordinate a launch
+  is a property of the engine — Atlas says `--rank`/`--world-size` where vLLM
+  says `--node-rank`/`--nnodes`, llama.cpp dials workers with `--rpc`, and
+  `vllm-ray` (Ray) and `trtllm` (`mpirun -H`) rendezvous outside the serve
+  command and so declare nothing. Declaring nothing is the base default and
+  disables the check, which is what an out-of-tree runtime built against an
+  older base class gets. It is a **warning** because the *single-node*
+  direction breaks: these flags are appended unconditionally by
+  `generate_node_command` (none of the `reconcile_flag_in_command` guarding
+  that `--served-model-name` and `--distributed-executor-backend` get), so
+  multi-node merely emits them twice and argparse drops the recipe's — but
+  under `world_nodes <= 1` sparkrun appends *nothing*, and the recipe's
+  `--nnodes 2` plus the author's head IP survive verbatim into a launch that
+  rendezvouses with a host that is not there, or trips sglang's
+  `(tp*pp) % nnodes == 0` assert before binding a port (issue #284).
+  `--data-parallel-size` and sglang's `--dp-size` are excluded: they are
+  injected only when the template did not supply them, so writing them is a
+  supported choice rather than a collision.
 - Every check runs through `_safe`, so a check that trips over an unexpected
   recipe shape costs its own finding and nothing else — it must not be able to
   block a launch it was only meant to describe.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1834,16 +1834,26 @@ Catalogue notes worth knowing before adding a check:
   spread.
 - **`inline-script` names tools, never shape.** A recipe carrying a program —
   a heredoc'd patch script, `sed -i` over the installed package, a launch-time
-  `pip install` — is doing what `mods:` exists for, and the argument is
-  sparkrun-specific rather than stylistic: the three homes render differently
-  and only one leaves the script alone. `command:` goes through
-  `render_command`, whose escape mode is inferred *from the template*
+  `pip install` — is building an image at launch, out of a string. It offers
+  **two peer remedies** rather than steering to one: publish a custom
+  container image (once, at build time, by the tooling built for it — right
+  when the change is stable or expensive, and costs a registry to publish to)
+  or add a `mods:` entry (travels with the recipe, needs no build
+  infrastructure — right when publishing is impractical or the change is small
+  and recipe-specific). A mod still runs per node per launch; that cost is
+  inherent to patching at runtime and is deliberately *not* the finding's
+  argument. What both buy is that the script becomes a **file**: reviewable on
+  its own, and never passed through the placeholder renderer. That second half
+  is sparkrun-specific rather than stylistic, because the homes render
+  differently and only the file forms leave the script alone. `command:` goes
+  through `render_command`, whose escape mode is inferred *from the template*
   (`uses_brace_escapes`), so an embedded program must double every literal
   brace and drags the whole template into v1 escape mode — one missed brace
   mis-renders it silently. A `pre_exec` string goes through
   `render_hook_command`, which does not collapse `{{` but still substitutes
   `{name}`, so a program is exposed to a collision with any config key it
-  spells. A mod's `run.sh` is `docker cp`'d verbatim and never rendered. Shape
+  spells. A mod's `run.sh`, and anything baked into the image, is never
+  rendered at all. Shape
   is deliberately *not* a signal: the corpus clusters at 10–19 command lines
   with nothing over 40, so a line-count threshold would report the recipes with
   the most flags rather than the ones carrying code. Every signal measures zero

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -589,7 +589,7 @@ executor_config:
 | `privileged`     | bool   | `true`      | `--privileged` | Privileged mode                                                                                                     |
 | `gpus`           | string | `"all"`     | (see below)    | GPU device spec (`all`, `device=0,1`)                                                                               |
 | `gpu_access_mode`| string | platform    | `--device` / `--gpus` | How the GPU request is spelled: `cdi` → `--device nvidia.com/gpu=<id>`, `gpus` → `--gpus <gpus>`. Defaults per hardware platform (DGX Spark/GB10 → `gpus`, everything else → `cdi`) |
-| `ipc`            | string | `"shareable"` | `--ipc`      | IPC namespace. `host` exposes the workload's `/dev/shm` semaphores to systemd-logind's `RemoveIPC` reaper — see [EXECUTORS.md](docs/EXECUTORS.md#ipc-namespace-ipc-and-shm_size) |
+| `ipc`            | string | `"shareable"` | `--ipc`      | IPC namespace. `host` exposes the workload's `/dev/shm` semaphores to systemd-logind's `RemoveIPC` reaper, and needs `--trust` for an untrusted recipe — see [EXECUTORS.md](docs/EXECUTORS.md#ipc-namespace-ipc-and-shm_size) |
 | `shm_size`       | string | `"32gb"`    | `--shm-size`   | Shared memory size. Ignored by Docker when `ipc: host`                                                               |
 | `network`        | string | `"host"`    | `--network`    | Network mode                                                                                                        |
 | `entrypoint`     | string | `null`      | `--entrypoint` | Override the image `ENTRYPOINT`. `null` leaves it untouched; `""` clears it so sparkrun's serve command runs directly |

--- a/RECIPES.md
+++ b/RECIPES.md
@@ -589,8 +589,8 @@ executor_config:
 | `privileged`     | bool   | `true`      | `--privileged` | Privileged mode                                                                                                     |
 | `gpus`           | string | `"all"`     | (see below)    | GPU device spec (`all`, `device=0,1`)                                                                               |
 | `gpu_access_mode`| string | platform    | `--device` / `--gpus` | How the GPU request is spelled: `cdi` → `--device nvidia.com/gpu=<id>`, `gpus` → `--gpus <gpus>`. Defaults per hardware platform (DGX Spark/GB10 → `gpus`, everything else → `cdi`) |
-| `ipc`            | string | `"host"`    | `--ipc`        | IPC namespace                                                                                                       |
-| `shm_size`       | string | `"10.24gb"` | `--shm-size`   | Shared memory size                                                                                                  |
+| `ipc`            | string | `"shareable"` | `--ipc`      | IPC namespace. `host` exposes the workload's `/dev/shm` semaphores to systemd-logind's `RemoveIPC` reaper — see [EXECUTORS.md](docs/EXECUTORS.md#ipc-namespace-ipc-and-shm_size) |
+| `shm_size`       | string | `"32gb"`    | `--shm-size`   | Shared memory size. Ignored by Docker when `ipc: host`                                                               |
 | `network`        | string | `"host"`    | `--network`    | Network mode                                                                                                        |
 | `entrypoint`     | string | `null`      | `--entrypoint` | Override the image `ENTRYPOINT`. `null` leaves it untouched; `""` clears it so sparkrun's serve command runs directly |
 | `user`           | string | `null`      | `--user`       | UID:GID or `$SHELL_USER` (auto: `$(id -u):$(id -g)` + mount passwd/group)                                           |

--- a/docs/EXECUTORS.md
+++ b/docs/EXECUTORS.md
@@ -81,8 +81,8 @@ lists. Falsy values fall through to the dataclass defaults.
 | `privileged`          | bool        | Docker              | `True`        | Off in rootless mode.                                                                          |
 | `gpus`                | str         | Docker, Local, K8s  | `"all"`       | The GPU spec. Docker spells it per `gpu_access_mode`. Local translates `device=0,2` → `CUDA_VISIBLE_DEVICES`. K8s extracts a count for `nvidia.com/gpu`. |
 | `gpu_access_mode`     | str         | Docker              | `"cdi"`       | `cdi` → `--device nvidia.com/gpu=<id>`; `gpus` → `--gpus <gpus>`. Platform-defaulted (DGX Spark pins `gpus`). |
-| `ipc`                 | str         | Docker              | `"host"`      | `--ipc=host`. K8s drops.                                                                       |
-| `shm_size`            | str         | Docker              | `"25gb"`      | `--shm-size`. K8s drops.                                                                       |
+| `ipc`                 | str         | Docker              | `"shareable"` | `--ipc`. Own IPC namespace + own `/dev/shm`, joinable via `--ipc=container:<name>`. **Not `host`**: see below. K8s drops. |
+| `shm_size`            | str         | Docker              | `"32gb"`      | `--shm-size`. Only applies when `ipc` is not `host` (Docker ignores it otherwise). K8s drops.  |
 | `network`             | str         | Docker              | `"host"`      | `--network`. K8s drops.                                                                        |
 | `user`                | str?        | Docker              | `None`        | `--user`. Sentinel `"$SHELL_USER"` expands to `$(id -u):$(id -g)` + bind-mounts passwd/group.  |
 | `security_opt`        | list[str]?  | Docker              | `None`        | Repeated `--security-opt`. Defaults to `["no-new-privileges"]` in rootless mode.               |
@@ -181,6 +181,47 @@ launch's own accelerator flags. Everything is fail-open: unreachable host,
 timeout, unresolvable executor, or `SPARKRUN_NO_IMAGE_PROBE=1` all read as
 "proceed". The base implementation returns `None`, so container-less (`local`)
 and provider executors never block a launch.
+
+### IPC namespace (`ipc`) and `shm_size`
+
+The default is `shareable`, **not** `host`. The two settings are coupled: Docker
+ignores `--shm-size` whenever `--ipc=host`, because the container then simply
+gets the host's `/dev/shm` (typically 50% of RAM). Change one and you change
+what the other means.
+
+`ipc: host` is unsafe in sparkrun's default configuration. The container runs as
+the SSH user (`--user $(id -u):$(id -g)`), so under a host IPC namespace every
+POSIX semaphore and shared-memory segment the workload creates is a host file
+owned by a regular UID. systemd-logind with `RemoveIPC=yes` — the Ubuntu 24.04 /
+DGX OS default — deletes exactly those objects `UserStopDelaySec` (10s) after
+that user's last login session ends. sparkrun launches detached (`docker exec -d`)
+and then closes its SSH session, so a workload still in Python's multiprocessing
+bootstrap when the reaper runs dies with:
+
+```text
+File "/usr/lib/python3.12/multiprocessing/synchronize.py", line 115, in __setstate__
+    self._semlock = _multiprocessing.SemLock._rebuild(*state)
+FileNotFoundError: [Errno 2] No such file or directory
+```
+
+A workload that gets past that point first survives indefinitely — unlinking a
+name does not invalidate an already-open handle — which is why the failure is
+intermittent, why longer startups (large models, graph capture) fail more often
+than short ones, and why holding an unrelated SSH session open makes it vanish.
+Running as root also masks it, since logind never reaps system UIDs.
+
+A container-owned namespace is immune: logind walks `/dev/shm` itself, not
+arbitrary mounts. `shareable` is preferred over `private` because it costs
+nothing and still lets a second container on the same host join with
+`--ipc=container:<name>`.
+
+Keep `ipc: host` only for cross-*container* shared memory on one host (e.g.
+intra-node NCCL between separate containers). When you do, either enable
+lingering for the SSH user (`sudo loginctl enable-linger <user>`) or set
+`RemoveIPC=no` in `/etc/systemd/logind.conf` on every host; `sparkrun setup
+check` reports this combination, and the executor warns at launch. Note the
+`local` executor has the same exposure by construction — it runs natively, with
+no namespace to hide in.
 
 ### NVIDIA GPU access mode
 

--- a/docs/EXECUTORS.md
+++ b/docs/EXECUTORS.md
@@ -223,6 +223,13 @@ check` reports this combination, and the executor warns at launch. Note the
 `local` executor has the same exposure by construction — it runs natively, with
 no namespace to hide in.
 
+**`ipc` is trust-gated on its value.** A recipe may narrow the namespace freely
+(`private`, `shareable`, `none`), but an untrusted recipe — one from a
+non-default registry or a URL — cannot select `host` or `container:<name>`
+without `--trust`. Both reach *outside* the container: the host's `/dev/shm`
+holds every other tenant's POSIX shared memory and semaphores, and a container
+name is derivable from a cluster_id. See [SECURITY.md](SECURITY.md).
+
 ### NVIDIA GPU access mode
 
 There are two ways to ask Docker for NVIDIA GPUs and neither works everywhere,

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -140,3 +140,71 @@ plugins:
 `plugins.paths` stays reserved for discovery. Everything else under `plugins`
 is a plugin's own namespace, so a plugin never needs a bespoke top-level config
 block or a property on `SparkrunConfig`.
+
+## Contributing a recipe registry
+
+A plugin whose recipes are inert without it can declare the registry that holds
+them, so `@<registry>/<recipe>` resolves for anyone with the plugin enabled and
+nobody has to `sparkrun registry add` anything:
+
+```python
+from sparkrun.plugins import RegistryEntry, register_default_registry
+
+
+def register(v):
+    register_default_registry(
+        RegistryEntry(
+            name="coldsnap",
+            url="https://github.com/sparksq/sparkrun-recipes.git",
+            subpath="coldsnap-recipes",
+            description="Qualified ColdSnap recipes",
+            visible=False,       # stays out of `sparkrun list`; @coldsnap/… still resolves
+        ),
+        owner="coldsnap",
+    )
+```
+
+Call it once per registry. `enabled` and `visible` are honored, so a control or
+opt-in lane can ship disabled.
+
+**Declarations are an overlay, not a config edit.** They are merged into the
+list `RegistryManager` loads and are never written to `registries.yaml`, so
+disabling or uninstalling the plugin takes its registries with it and leaves
+nothing to clean up. The user's own file always wins on a name collision, which
+is how they repoint a declared registry at an internal mirror.
+
+User decisions still stick. `registry disable` / `trust` / `untrust` on a
+declared registry **materializes** it — writes it into `registries.yaml` as an
+ordinary entry the user now owns — and `registry remove` records a tombstone so
+the declaration cannot put it back on the next launch. `sparkrun registry list`
+grows a `Source` column showing `plugin:<owner>` when anything is declared.
+
+Four rules worth knowing before you rely on this:
+
+- **Registration does no I/O.** It records intent and validates; it does not
+  clone, read or fetch. `init_sparkrun` runs on every shell completion, so
+  anything expensive here lands on the interactive path — which is also why a
+  plugin cannot point at a remote `.sparkrun/registry.yaml` and have its
+  *names* come from there. Declare them in code; the repo manifest stays for
+  users who add the registry by URL by hand.
+- **Trust depends on where the plugin came from.** An in-tree plugin may ship
+  `trusted=True` (it arrives through sparkrun's own review and release gate).
+  For an out-of-tree plugin it is forced to `False` and the user grants it with
+  `sparkrun registry trust <name>` — installing a plugin says "I want this
+  capability", not "I grant its recipe repo standing permission to run
+  lifecycle hooks from whatever it contains next month". Document that step in
+  your install instructions if your recipes use `pre_exec` / `post_exec` /
+  `post_commands`. The tier is set by the loader; a plugin cannot claim it.
+- **Names are validated at declaration and raise.** `validate_registry_name`
+  checks the *registry URL's* GitHub org against the reserved-name tables, and
+  `assert_safe_registry_entry` checks the name and every subpath as filesystem
+  paths. A reserved name from the wrong org fails at bootstrap, not later — so
+  if you want a name reserved to your org, that entry belongs in
+  `EXTERNAL_RESERVED_NAMES` in core.
+- **You cannot redefine a shipped default.** Declaring `official` is refused
+  with a warning naming your plugin, rather than silently ignored. A new name
+  is the supported use; shadowing a curated one is not.
+
+Nothing is fetched until something clones it, so suggest `sparkrun registry
+update` after your plugin is first enabled rather than paying a clone inside
+the next `sparkrun run`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -108,8 +108,24 @@ choke point:
 - The undocumented `cluster_config` launch overrides
   (`resolved_model_path` / `remote_cache_dir` / `local_cache_dir`), which
   identity-mount a host directory and repoint the serve argument at it.
+- **`executor_config.ipc`** (`_UNTRUSTED_IPC_MODES`), gated on its *value*
+  rather than its presence: an untrusted recipe may pick any mode that gives
+  the container a fresh IPC namespace (`private`, `shareable`, `none`, or an
+  empty value), but not one that reaches outside it. `host` shares the host's
+  IPC namespace and `/dev/shm` — read/write access to every other tenant's
+  POSIX shared memory and semaphores on that machine, including the ability to
+  delete them — and `container:<name>` joins one specific other workload's
+  namespace, which is a *targeted* lateral read since sparkrun container names
+  are derivable from a cluster_id. The allowlist shape means an unrecognised
+  or non-string value fails closed too.
 
-Innocuous resource knobs are deliberately **not** gated: `shm_size`, `ipc`,
+  This knob was ungated while `host` was the default, when setting it changed
+  nothing. It became an escalation when the default moved to a container-owned
+  namespace (see [EXECUTORS.md](EXECUTORS.md#ipc-namespace-ipc-and-shm_size)):
+  an untrusted recipe asking for `host` is asking to leave the sandbox that
+  justifies running its serve `command` without a prompt.
+
+Innocuous resource knobs are deliberately **not** gated: `shm_size`,
 `network`, `memory_limit`, `ulimit`, `restart_policy`, `auto_remove`,
 `labels`.
 

--- a/src/sparkrun/api/_run.py
+++ b/src/sparkrun/api/_run.py
@@ -652,6 +652,7 @@ def _evict_superseded_deployments(
     cluster_def,
     config,
     sctx: "SparkrunContext | None",
+    strict: bool = False,
 ) -> "tuple[list[str], set[str] | None]":
     """Stop this intent's earlier deployments that sit on the hosts we're about to use.
 
@@ -682,8 +683,11 @@ def _evict_superseded_deployments(
       within *candidate_hosts*, not just the overlapping ones — half a
       distributed job is dead weight either way.
 
-    Best-effort: discovery or teardown failures are logged and swallowed so
-    they can't block a launch that may well succeed anyway.
+    Discovery and teardown are best-effort by default so they cannot block a
+    normal launch that may still succeed.  Callers that must bind the same
+    host resources before their own launcher starts can set ``strict=True``;
+    then an unverified replacement aborts instead of predictably colliding
+    with the earlier workload.
 
     Returns:
         ``(evicted, observed_running)`` — the cluster_ids torn down (empty when
@@ -707,6 +711,8 @@ def _evict_superseded_deployments(
             v=sctx.variables if sctx is not None else None,
         )
     except Exception as e:
+        if strict:
+            raise RuntimeError("could not query cluster status before workload replacement: %s" % e) from e
         logger.debug("Could not query cluster status for eviction; skipping: %s", e)
         return [], None
 
@@ -740,9 +746,13 @@ def _evict_superseded_deployments(
         try:
             result = api.stop(cluster_id=cid, hosts=occupied[cid], cluster=cluster_def, sctx=sctx)
         except Exception as e:
+            if strict:
+                raise RuntimeError("could not stop earlier deployment %s: %s" % (cid, e)) from e
             logger.warning("Could not stop earlier deployment %s: %s — it may still hold GPU memory", cid, e)
             continue
         if result.hosts_failed:
+            if strict:
+                raise RuntimeError("teardown of earlier deployment %s was not confirmed on %s" % (cid, ", ".join(result.hosts_failed)))
             logger.warning(
                 "Teardown of earlier deployment %s did not confirm on %s — it may still hold GPU memory",
                 cid,

--- a/src/sparkrun/cli/_arena.py
+++ b/src/sparkrun/cli/_arena.py
@@ -211,7 +211,12 @@ def arena_benchmark_run(
     click.echo("sparkrun v%s — Spark Arena benchmark" % display_version(SparkrunConfig()))
     click.echo()
 
-    submission_id, profile_override = preflight_arena(local_test=local_test, ctx=ctx)
+    submission_id, profile_override = preflight_arena(
+        local_test=local_test,
+        ctx=ctx,
+        recipe_name=recipe_name,
+        dry_run=dry_run,
+    )
     profile = profile_override  # None in local-test mode, arena profile otherwise
 
     framework = output_file = None

--- a/src/sparkrun/cli/_arena_flow.py
+++ b/src/sparkrun/cli/_arena_flow.py
@@ -19,21 +19,133 @@ from sparkrun.core.benchmark_profiles import ARENA_BENCHMARK_PROFILE  # noqa: F4
 logger = logging.getLogger(__name__)
 
 
+def _is_interactive() -> bool:
+    """``sys.stdin.isatty()``, behind a seam so both branches are testable.
+
+    ``CliRunner`` replaces ``sys.stdin`` with a non-TTY stream for the duration
+    of an invocation, so the interactive path is otherwise unreachable from a
+    test — which would leave the branch that actually prompts unexercised.
+    """
+    return sys.stdin.isatty()
+
+
+def _count_phrase(counts: "dict[str, int]") -> str:
+    """ "3 warnings and 4 suggestions", omitting whichever level is absent."""
+    from sparkrun.core.validation import SUGGESTION, WARNING
+
+    parts = [
+        "%d %s%s" % (counts[level], label, "" if counts[level] == 1 else "s")
+        for level, label in ((WARNING, "warning"), (SUGGESTION, "suggestion"))
+        if counts[level]
+    ]
+    return " and ".join(parts)
+
+
+def validate_recipe_for_submission(recipe_name: str, *, ctx: click.Context, dry_run: bool = False) -> None:
+    """Show the *full* validation report and confirm before an arena submission.
+
+    The benchmark path already validates (``api._benchmark`` calls
+    ``validate_for_launch``), so this is not the launch's safety check — it
+    asks a different question.  ``validate_for_launch`` deliberately withholds
+    suggestions and collapses deprecations, because at launch you are usually
+    running someone else's recipe and the migration is not your work.  A
+    submission inverts both premises: the recipe is *yours*, it is about to be
+    published, and reproducibility for whoever reads it later is the whole
+    point.  So this is the ``recipe validate`` report — every severity, nothing
+    collapsed — shown at the one moment the author can still act on it.
+
+    Gated to the arena paths for that reason and no other.  An ordinary
+    ``sparkrun benchmark`` publishes nothing, and printing suggestions there
+    would undo the rule the launch paths share.
+
+    Errors abort without prompting: the launch would refuse anyway, and
+    "continue?" is not a real question when the answer cannot be yes.  Warnings
+    and suggestions prompt, because both are things a submitter can reasonably
+    decide to accept.  A clean recipe says nothing at all — a report with no
+    findings is noise between the user and their benchmark.
+    """
+    from sparkrun.core.validation import ERROR, SUGGESTION, WARNING, validate_recipe
+    from sparkrun.utils.cli_formatters import format_validation_report
+    from ._common import _get_config_and_registry, _get_context, _load_recipe
+
+    sctx = _get_context(ctx)
+    config, _ = _get_config_and_registry()
+    recipe, _path, _mgr = _load_recipe(config, recipe_name)
+
+    issues = validate_recipe(recipe, config=config, v=sctx.variables)
+    if not issues:
+        return
+
+    counts = {level: sum(1 for i in issues if i.severity == level) for level in (ERROR, WARNING, SUGGESTION)}
+    click.echo(
+        format_validation_report(
+            recipe.qualified_name,
+            issues,
+            title="Validating recipe before submission",
+        )
+    )
+    click.echo()
+
+    if counts[ERROR]:
+        click.echo(
+            "The recipe has %d error%s and cannot be launched, so it cannot be submitted."
+            % (counts[ERROR], "" if counts[ERROR] == 1 else "s"),
+            err=True,
+        )
+        sys.exit(1)
+
+    click.echo(
+        "The recipe contains %s. We suggest that you address all of these issues before submitting a "
+        "benchmark; problematic recipes may not be published to Spark Arena." % _count_phrase(counts)
+    )
+
+    if dry_run:
+        click.echo("[dry-run] Not prompting; nothing will be submitted.")
+        click.echo()
+        return
+
+    # Not a security gate (that is the hook trust prompt, which refuses without
+    # a TTY). This is quality advice on a path that people script, so a
+    # non-interactive run proceeds and says so rather than aborting a
+    # submission that worked yesterday.
+    if not _is_interactive():
+        click.echo("Not running interactively — continuing without confirmation.")
+        click.echo()
+        return
+
+    if not click.confirm("Continue with the benchmark and submission?", default=False):
+        click.echo("Aborted.")
+        sys.exit(1)
+    click.echo()
+
+
 def preflight_arena(
     *,
     local_test: bool,
     ctx: click.Context,
+    recipe_name: str,
+    dry_run: bool = False,
 ) -> tuple[str, str | None]:
-    """Authenticate (unless ``local_test``) and generate a stable submission id.
+    """Authenticate (unless ``local_test``), validate the recipe, mint a submission id.
 
     Returns ``(submission_id, profile)`` — profile is ``None`` in local-test
     mode (caller chooses what to use) or the arena's pinned profile name.
+
+    Validation runs *after* auth so a user who is not logged in is told the
+    thing that blocks them outright before being asked to review advice, and
+    so the report — and its prompt — sit directly above the launch they gate.
+    It runs in local-test mode too: that path simulates the upload, and
+    rehearsing a submission without its checks would defeat the rehearsal.
+
+    *recipe_name* is required rather than optional so a future arena entry
+    point cannot bypass the gate by forgetting to pass it.
     """
     from sparkrun.arena.upload import generate_submission_id
 
     if local_test:
         click.echo("[local-test] Skipping authentication — upload will be simulated.")
         click.echo()
+        validate_recipe_for_submission(recipe_name, ctx=ctx, dry_run=dry_run)
         submission_id = generate_submission_id()
         return submission_id, None
 
@@ -53,6 +165,8 @@ def preflight_arena(
 
     click.echo("Authentication verified.")
     click.echo()
+
+    validate_recipe_for_submission(recipe_name, ctx=ctx, dry_run=dry_run)
 
     submission_id = generate_submission_id()
     return submission_id, ARENA_BENCHMARK_PROFILE

--- a/src/sparkrun/cli/_benchmark.py
+++ b/src/sparkrun/cli/_benchmark.py
@@ -278,7 +278,12 @@ def _invoke_benchmark(ctx, *, category, **kwargs):
     if arena_flag:
         from sparkrun.cli._arena_flow import preflight_arena
 
-        arena_submission_id, arena_profile = preflight_arena(local_test=local_test, ctx=ctx)
+        arena_submission_id, arena_profile = preflight_arena(
+            local_test=local_test,
+            ctx=ctx,
+            recipe_name=kwargs.get("recipe_name"),
+            dry_run=kwargs.get("dry_run", False),
+        )
         # Only override profile when user did not supply one explicitly
         if not kwargs.get("profile") and arena_profile:
             kwargs["profile"] = arena_profile

--- a/src/sparkrun/cli/_cluster.py
+++ b/src/sparkrun/cli/_cluster.py
@@ -1214,6 +1214,70 @@ def cluster_check_job(ctx, target, hosts, hosts_file, cluster_name, tp_override,
         sys.exit(1)
 
 
+def _format_head_hardware(summary: dict) -> list[tuple[str, str]]:
+    """Render a :func:`~sparkrun.diagnostics.summarize_host_diagnostics` result.
+
+    Returns ``(label, value)`` rows in display order, collapsing the fields
+    that are only meaningful together (kernel/arch qualify the OS, core counts
+    qualify the CPU, the storage driver and nvidia runtime qualify Docker).  A
+    row is emitted only when the summary carries its primary field, so a host
+    without ``nvcc`` or without Docker simply has fewer lines.
+    """
+    rows: list[tuple[str, str]] = []
+
+    def add(label: str, value: str) -> None:
+        if value:
+            rows.append((label, value))
+
+    product = summary.get("product", "")
+    board = summary.get("board", "")
+    if product and board and board != product:
+        add("platform", "%s (board: %s)" % (product, board))
+    else:
+        add("platform", product or board)
+
+    os_name = summary.get("os", "")
+    os_detail = []
+    if summary.get("kernel"):
+        os_detail.append("kernel %s" % summary["kernel"])
+    if summary.get("arch"):
+        os_detail.append(summary["arch"])
+    add("os", "%s (%s)" % (os_name, ", ".join(os_detail)) if os_name and os_detail else os_name)
+
+    cpu = summary.get("cpu_model", "")
+    cores, threads = summary.get("cpu_cores"), summary.get("cpu_threads")
+    if cpu and cores:
+        counts = "%d cores" % cores + (" / %d threads" % threads if threads and threads != cores else "")
+        add("cpu", "%s (%s)" % (cpu, counts))
+    else:
+        add("cpu", cpu)
+
+    if summary.get("ram_total_gb"):
+        add("memory", "%.1f GB" % summary["ram_total_gb"])
+
+    gpu = summary.get("gpu_name", "")
+    if gpu and summary.get("gpu_memory_gb"):
+        add("gpu", "%s (%.1f GB)" % (gpu, summary["gpu_memory_gb"]))
+    else:
+        add("gpu", gpu)
+
+    add("gpu driver", summary.get("gpu_driver", ""))
+    add("cuda (nvcc)", summary.get("cuda_version", ""))
+    add("jetpack", summary.get("jetpack_version", ""))
+    add("bios", summary.get("bios_version", ""))
+
+    docker = summary.get("docker_version", "")
+    if docker:
+        detail = []
+        if summary.get("docker_storage_driver"):
+            detail.append("storage: %s" % summary["docker_storage_driver"])
+        if "docker_nvidia_runtime" in summary:
+            detail.append("nvidia runtime: %s" % ("yes" if summary["docker_nvidia_runtime"] else "no"))
+        add("docker", "%s (%s)" % (docker, ", ".join(detail)) if detail else docker)
+
+    return rows
+
+
 @cluster.command("inspect", hidden=HIDE_ADVANCED_OPTIONS)
 @click.argument("name", type=CLUSTER_NAME, required=False, default=None)
 @host_options
@@ -1227,6 +1291,10 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
     SSH user, cache dirs) and checks whether cache directories exist on
     each remote host.  Useful for diagnosing configuration, transfer, or
     permission issues without running a job.
+
+    Also reports the head node's hardware and driver/software versions
+    (platform, OS/kernel, CPU/RAM, GPU + driver, CUDA, Docker).  Run
+    `sparkrun setup diagnose` for the full per-host inventory.
 
     NAME is an optional cluster name (equivalent to --cluster NAME).
 
@@ -1300,6 +1368,7 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
 
     if dry_run:
         click.echo("[dry-run] Would inspect cluster config and cache dirs on %d host(s)" % len(host_list))
+        click.echo("[dry-run] Would probe head node hardware on %s" % host_list[0])
         return
 
     # TODO: remote sparkrun cache path should go through same effective route as remote hf cache resolution
@@ -1323,6 +1392,16 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
         hf_cache_dir=local_hf,
         sparkrun_cache_dir=local_sparkrun,
     )
+
+    # Head-node hardware / driver versions.  Scoped to the head for the same
+    # reason the NCCL env block is: one representative host answers "what am I
+    # actually launching on", and a per-host sweep is what `setup diagnose`
+    # already exists for.
+    from sparkrun.diagnostics import collect_spark_diagnostics, summarize_host_diagnostics
+
+    head_host = host_list[0]
+    head_diag = collect_spark_diagnostics([head_host], ssh_kwargs=ssh_kwargs).get(head_host, {})
+    head_hardware = summarize_host_diagnostics(head_diag)
 
     # Scheduler the cluster would launch with.  ``inspect`` reports *effective*
     # configuration, and an unset cluster scheduler still resolves to one — so
@@ -1358,6 +1437,7 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
         data = {
             "config": effective_config,
             "hosts": list(host_list),
+            "head_node": {"host": head_host, "hardware": head_hardware},
             "local": {
                 "sparkrun_cache": {
                     "path": local_status.sparkrun_dir,
@@ -1412,6 +1492,15 @@ def cluster_inspect(ctx, name, hosts, hosts_file, cluster_name, dry_run, output_
     if cluster_cfg.executor:
         click.echo("  executor:           %s" % cluster_cfg.executor)
     click.echo("  hosts:              %s" % ", ".join(host_list))
+    click.echo()
+
+    # Head-node hardware section
+    click.echo("Head Node Hardware (%s):" % head_host)
+    if head_hardware:
+        for label, value in _format_head_hardware(head_hardware):
+            click.echo("  %-19s %s" % (label + ":", value))
+    else:
+        click.echo("  (hardware probe failed — see `sparkrun setup diagnose` for details)")
     click.echo()
 
     # NCCL env section

--- a/src/sparkrun/cli/_registry.py
+++ b/src/sparkrun/cli/_registry.py
@@ -66,6 +66,10 @@ def registry_list(ctx, show_disabled, only_show_visible, output_json, config_pat
     # Determine which content columns to show
     has_tuning = any(r.tuning_subpath for r in display_registries)
     has_benchmarks = any(r.benchmark_subpath for r in display_registries)
+    # Only shown when something is plugin-declared: a user who did not add a
+    # registry should be able to see who did, but the column is noise on the
+    # overwhelmingly common all-local list.
+    has_declared = any(r.declared_by for r in display_registries)
 
     # Table header
     # "Stemless" is `visible`: whether a bare recipe stem resolves against this
@@ -78,6 +82,9 @@ def registry_list(ctx, show_disabled, only_show_visible, output_json, config_pat
     if has_benchmarks:
         header += f" {'Bench':<7}"
         sep_width += 8
+    if has_declared:
+        header += f" {'Source':<16}"
+        sep_width += 17
     click.echo(header)
     click.echo("-" * sep_width)
 
@@ -93,6 +100,9 @@ def registry_list(ctx, show_disabled, only_show_visible, output_json, config_pat
         if has_benchmarks:
             bench = "yes" if reg.benchmark_subpath else "no"
             row += f" {bench:<7}"
+        if has_declared:
+            source = ("plugin:%s" % reg.declared_by) if reg.declared_by else "config"
+            row += f" {source[:16]:<16}"
         click.echo(row)
 
 
@@ -202,9 +212,24 @@ def registry_remove(ctx, name, config_path=None):
 
     config, registry_mgr = _get_config_and_registry(config_path)
 
+    # Read the provenance before removing, so the message can be honest about
+    # what actually happened: a plugin-declared registry is suppressed rather
+    # than deleted (there is nothing in registries.yaml to delete), and saying
+    # "removed successfully" without that would leave the user unable to explain
+    # why re-enabling the plugin does not bring it back.
+    declared_by = ""
+    try:
+        declared_by = registry_mgr.get_registry(name).declared_by
+    except RegistryError:
+        pass
+
     try:
         registry_mgr.remove_registry(name)
-        click.echo(f"Registry '{name}' removed successfully.")
+        if declared_by:
+            click.echo(f"Registry '{name}' (declared by plugin '{declared_by}') removed and suppressed.")
+            click.echo(f"  It will not return while '{declared_by}' is installed. Undo with: sparkrun registry add <url>")
+        else:
+            click.echo(f"Registry '{name}' removed successfully.")
     except RegistryError as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
@@ -301,6 +326,8 @@ def registry_show(ctx, name, config_path=None):
     click.echo("Enabled:     %s" % ("yes" if entry.enabled else "no"))
     click.echo("Stemless:    %s" % ("yes" if entry.visible else "no"))
     click.echo("Trusted:     %s" % ("yes" if entry.trusted else "no"))
+    if entry.declared_by:
+        click.echo("Source:      declared by plugin '%s' (not in your configuration)" % entry.declared_by)
     if entry.tuning_subpath:
         click.echo("Tuning:      %s" % entry.tuning_subpath)
     if entry.benchmark_subpath:

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -72,10 +72,10 @@ _EXECUTOR_OVERRIDE_KEYS = frozenset(
 
 def _timing_tree_depth(ctx: click.Context) -> int | None:
     """Choose the ordinary ``run`` timing detail from global verbosity."""
+    from sparkrun.utils.cli_formatters import timing_tree_depth_for_verbosity
+
     verbose_count = (ctx.find_root().obj or {}).get("verbose", 0)
-    if isinstance(verbose_count, bool):
-        verbose_count = 1 if verbose_count else 0
-    return None if verbose_count >= 3 else max(2, 2 + verbose_count)
+    return timing_tree_depth_for_verbosity(verbose_count)
 
 
 def _echo_hub_notice() -> None:

--- a/src/sparkrun/cli/_run.py
+++ b/src/sparkrun/cli/_run.py
@@ -70,6 +70,14 @@ _EXECUTOR_OVERRIDE_KEYS = frozenset(
 )
 
 
+def _timing_tree_depth(ctx: click.Context) -> int | None:
+    """Choose the ordinary ``run`` timing detail from global verbosity."""
+    verbose_count = (ctx.find_root().obj or {}).get("verbose", 0)
+    if isinstance(verbose_count, bool):
+        verbose_count = 1 if verbose_count else 0
+    return None if verbose_count >= 3 else max(2, 2 + verbose_count)
+
+
 def _echo_hub_notice() -> None:
     """Report skipped HuggingFace Hub lookups, at most once per command.
 
@@ -940,7 +948,7 @@ def run(
     if show_timings and sctx.timing is not None:
         from sparkrun.utils.cli_formatters import format_launch_timings
 
-        _timings = format_launch_timings(sctx.timing.export())
+        _timings = format_launch_timings(sctx.timing.export(), max_depth=_timing_tree_depth(ctx))
         if _timings:
             click.echo()
             click.echo(_timings)

--- a/src/sparkrun/cli/_setup/_check.py
+++ b/src/sparkrun/cli/_setup/_check.py
@@ -28,7 +28,7 @@ from typing import Callable, TYPE_CHECKING
 
 import click
 
-from sparkrun.orchestration.executors.docker import GPU_ACCESS_CDI
+from sparkrun.orchestration.executors.docker import DOCKER_IPC_DEFAULT, DOCKER_IPC_HOST, GPU_ACCESS_CDI
 
 from .._common import host_options, json_option
 
@@ -73,6 +73,16 @@ class CheckContext:
     Empty (or missing a host) when resolution failed; see :meth:`cdi_required`.
     """
 
+    ipc_exposure: dict[str, str] = field(default_factory=dict)
+    """host -> the IPC namespace a launch on that host would put the workload in.
+
+    ``"host"`` means the workload's POSIX semaphores and shared memory land in
+    the *host's* ``/dev/shm`` — either a Docker ``ipc: host`` override or the
+    ``local`` executor, which runs natively and has no namespace at all.  Any
+    other value (or a missing host) means it does not; see
+    :meth:`shares_host_ipc`.
+    """
+
     @property
     def cluster_flag(self) -> str:
         """`` --cluster <name>`` suffix for guidance commands (empty if unknown)."""
@@ -89,6 +99,18 @@ class CheckContext:
         is the historical behavior (a missing spec is a hard failure).
         """
         return self.gpu_access_modes.get(host, GPU_ACCESS_CDI) == GPU_ACCESS_CDI
+
+    def shares_host_ipc(self, host: str) -> bool:
+        """Would a launch on *host* put the workload on the host IPC namespace?
+
+        Fails **quiet**, the opposite of :meth:`cdi_required`: an unresolvable
+        executor reads as "no". The two differ because a false positive costs
+        different things — a spurious CDI finding points at a real file, while
+        a spurious IPC finding tells the operator to change logind on a host
+        where nothing is at risk. A finding that fires on correct setups is how
+        a report teaches people to skim it.
+        """
+        return self.ipc_exposure.get(host, "") == DOCKER_IPC_HOST
 
 
 @dataclass
@@ -241,6 +263,65 @@ def _check_cdi_spec(state: HostState, ctx: CheckContext) -> CheckItem:
             _CDI_REGENERATE % ctx.cluster_flag,
         )
     return CheckItem("cdi_spec", "NVIDIA CDI spec (/etc/cdi/nvidia.yaml)", SKIP, "not needed — %s" % _CDI_UNUSED)
+
+
+#: systemd never reaps IPC for UIDs at or below this — ``SYSTEM_UID_MAX``, whose
+#: compiled-in default is 999. A root or system-user workload is not at risk,
+#: which is exactly why ``-o user=root`` "fixes" the failure (at the cost of the
+#: rootless hardening and a cache full of root-owned files).
+_LOGIND_SYSTEM_UID_MAX = 999
+
+_IPC_LABEL = "Host IPC vs systemd RemoveIPC"
+
+
+def _check_host_ipc(state: HostState, ctx: CheckContext) -> CheckItem | None:
+    """Would systemd-logind reap this host's workload IPC after launch?
+
+    Only applies when a launch here shares the *host's* IPC namespace — an
+    explicit Docker ``ipc: host`` (sparkrun defaults to ``shareable``, which is
+    immune) or the ``local`` executor, which runs natively and so has no
+    namespace to hide in. Everything else is omitted rather than reported OK:
+    there is no gap to describe.
+
+    The hazard needs all three of host IPC, a regular UID, and a user manager
+    that stops — so the check reports only when it can see all three, and any
+    one of them being absent or unknowable is a reason to stay quiet or say
+    "couldn't tell" rather than to warn.
+    """
+    facts = state.facts
+    if not ctx.shares_host_ipc(state.host):
+        return None
+
+    raw_uid = facts.get("CHECK_UID", "").strip()
+    try:
+        uid = int(raw_uid)
+    except (TypeError, ValueError):
+        return CheckItem("host_ipc", _IPC_LABEL, SKIP, "could not read the ssh user's UID")
+    if uid <= _LOGIND_SYSTEM_UID_MAX:
+        return None  # logind does not reap system users; nothing at risk
+
+    remove_ipc = facts.get("CHECK_LOGIND_REMOVE_IPC", "unknown").strip()
+    linger = facts.get("CHECK_LOGIND_LINGER", "unknown").strip()
+    user = facts.get("CHECK_USER", "the ssh user")
+
+    if linger == "1":
+        return CheckItem("host_ipc", _IPC_LABEL, OK, "lingering enabled for '%s', so its user manager never stops" % user)
+    if remove_ipc == "no":
+        return CheckItem("host_ipc", _IPC_LABEL, OK, "logind RemoveIPC=no")
+    if remove_ipc != "yes":
+        return CheckItem("host_ipc", _IPC_LABEL, SKIP, "could not read logind's RemoveIPC setting")
+
+    detail = "RemoveIPC=yes and no lingering for '%s' (uid %d)" % (user, uid)
+    if linger != "0":
+        detail += "; lingering could not be confirmed"
+    detail += " — logind deletes this workload's /dev/shm semaphores shortly after the launching SSH session closes"
+    return CheckItem(
+        "host_ipc",
+        _IPC_LABEL,
+        WARN,
+        detail,
+        "sudo loginctl enable-linger %s — or drop the 'ipc: host' override (sparkrun defaults to '%s')" % (user, DOCKER_IPC_DEFAULT),
+    )
 
 
 def _check_earlyoom(state: HostState, ctx: CheckContext) -> CheckItem:
@@ -411,6 +492,7 @@ SETUP_CHECKS: tuple[SetupCheck, ...] = (
     SetupCheck("docker_usable", _check_docker_usable),
     SetupCheck("nvidia_ctk", _check_nvidia_ctk),
     SetupCheck("cdi_spec", _check_cdi_spec),
+    SetupCheck("host_ipc", _check_host_ipc),
     SetupCheck("earlyoom", _check_earlyoom),
     SetupCheck("sudoers", _check_sudoers),
     SetupCheck("ssh_mesh", _check_ssh_mesh),
@@ -450,17 +532,22 @@ def register(setup_group) -> None:
     group is defined there).
     """
 
-    def _resolve_gpu_access_modes(host_list, *, cluster_name, hosts, hosts_file, config) -> dict[str, str]:
-        """Map each host to the ``gpu_access_mode`` a launch on it would resolve to.
+    def _resolve_executor_facts(host_list, *, cluster_name, hosts, hosts_file, config) -> tuple[dict[str, str], dict[str, str]]:
+        """Map each host to the ``gpu_access_mode`` and IPC namespace a launch would use.
 
         Runs the *real* executor resolution chain per host (the platform tier is
-        keyed off that host's hardware), so the check reports on the same value
-        the launch would use rather than re-deriving the rule. Mirrors the
+        keyed off that host's hardware), so the checks report on the same values
+        the launch would use rather than re-deriving the rules. Mirrors the
         launcher's fallback: with no cluster definition, hardware defaults to
         DGX Spark.
 
-        Best-effort — any failure yields an empty/partial map and
-        :meth:`CheckContext.cdi_required` falls back to "CDI is required".
+        Sees cluster- and config-level settings but not recipe-level ones — a
+        recipe pinning ``executor_config: {ipc: host}`` is invisible here, which
+        is why the executor also warns at command-generation time.
+
+        Best-effort — any failure yields empty/partial maps;
+        :meth:`CheckContext.cdi_required` then falls back to "CDI is required"
+        and :meth:`CheckContext.shares_host_ipc` to "not exposed".
         """
         from sparkrun.core.hardware import default_dgx_spark_hardware
         from sparkrun.orchestration.executor import resolve_executor
@@ -468,6 +555,7 @@ def register(setup_group) -> None:
         from .._common import _get_cluster_manager
 
         modes: dict[str, str] = {}
+        ipc_exposure: dict[str, str] = {}
         cluster_def = None
         try:
             cluster_mgr = _get_cluster_manager()
@@ -484,9 +572,18 @@ def register(setup_group) -> None:
                 hw = cluster_def.hardware_for(host) if cluster_def is not None else default_dgx_spark_hardware()
                 executor = resolve_executor(cluster=cluster_def, config=config, host_hardware=hw, rootless=False, auto_user=False)
                 modes[host] = executor.config.gpu_access_mode
+                # A native (`local`) job has no IPC namespace at all, so it is
+                # on the host's by construction — the same exposure an
+                # `ipc: host` container has, reached a different way. Provider
+                # executors (k8s, modal) don't run on this host; omit them.
+                name = getattr(executor, "executor_name", "")
+                if name == "docker":
+                    ipc_exposure[host] = (executor.config.ipc or "").strip().lower()
+                elif name == "local":
+                    ipc_exposure[host] = DOCKER_IPC_HOST
             except Exception:
-                logger.debug("Could not resolve gpu_access_mode for %s", host, exc_info=True)
-        return modes
+                logger.debug("Could not resolve executor facts for %s", host, exc_info=True)
+        return modes, ipc_exposure
 
     @setup_group.command("check")
     @host_options
@@ -496,8 +593,8 @@ def register(setup_group) -> None:
         """Check cluster hosts against the setup steps, without changing anything.
 
         Probes each host for the things ``sparkrun setup wizard`` configures
-        (Docker access, NVIDIA CDI, earlyoom, sudoers, SSH mesh, CX7) and
-        reports gaps with the command that fixes each. Uses the default
+        (Docker access, NVIDIA CDI, host IPC reaping, earlyoom, sudoers, SSH
+        mesh, CX7) and reports gaps with the command that fixes each. Uses the default
         cluster unless ``--cluster``/``--hosts`` is given. Read-only.
 
         Examples:
@@ -521,16 +618,18 @@ def register(setup_group) -> None:
         host_list, user, ssh_kwargs = _resolve_setup_context(hosts, hosts_file, cluster_name, config, user=None)
 
         multi_host = len(host_list) > 1
+        gpu_access_modes, ipc_exposure = _resolve_executor_facts(
+            host_list,
+            cluster_name=cluster_name,
+            hosts=hosts,
+            hosts_file=hosts_file,
+            config=config,
+        )
         check_ctx = CheckContext(
             cluster_name=cluster_name,
             multi_host=multi_host,
-            gpu_access_modes=_resolve_gpu_access_modes(
-                host_list,
-                cluster_name=cluster_name,
-                hosts=hosts,
-                hosts_file=hosts_file,
-                config=config,
-            ),
+            gpu_access_modes=gpu_access_modes,
+            ipc_exposure=ipc_exposure,
         )
 
         target = "cluster '%s'" % cluster_name if cluster_name else "%d host(s)" % len(host_list)

--- a/src/sparkrun/core/cluster_manager.py
+++ b/src/sparkrun/core/cluster_manager.py
@@ -198,6 +198,15 @@ class ClusterDefinition:
     description: str = ""
     user: str | None = None
     cache_dir: str | None = None
+    sparkrun_cache_dir: str | None = None
+    """Remote cluster-specific sparkrun state/cache root.
+
+    This is independent of :attr:`cache_dir`, which remains the remote Hugging
+    Face/model cache.  Consumers derive their own subdirectories unless a
+    narrower plugin setting overrides them.
+    """
+    plugins: dict[str, dict[str, Any]] = field(default_factory=dict)
+    """Cluster-local plugin settings, layered above user plugin defaults."""
     transfer_mode: str | None = None
     transfer_interface: str | None = None
     topology: str | None = None
@@ -382,6 +391,16 @@ class ClusterDefinition:
             return default_dgx_spark_hardware()
         return hw
 
+    def plugin_settings(self, name: str) -> dict[str, Any]:
+        """Return an isolated, validated cluster-local plugin mapping."""
+
+        raw = self.plugins.get(name, {})
+        if not isinstance(raw, dict):
+            raise ClusterError("cluster '%s' plugins.%s must be a mapping" % (self.name, name))
+        if "paths" in raw:
+            raise ClusterError("cluster '%s' plugins.%s cannot declare plugin discovery paths" % (self.name, name))
+        return dict(raw)
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to a JSON-serializable dictionary (omits None optional fields)."""
         d: dict[str, Any] = {"name": self.name, "hosts": self.hosts, "description": self.description}
@@ -389,6 +408,10 @@ class ClusterDefinition:
             d["user"] = self.user
         if self.cache_dir:
             d["cache_dir"] = self.cache_dir
+        if self.sparkrun_cache_dir:
+            d["sparkrun_cache_dir"] = self.sparkrun_cache_dir
+        if self.plugins:
+            d["plugins"] = {name: dict(settings) for name, settings in self.plugins.items()}
         if self.transfer_mode:
             d["transfer_mode"] = self.transfer_mode
         if self.transfer_interface:
@@ -586,6 +609,8 @@ class ClusterManager:
         scheduler: str | None = None,
         max_gpu_memory_utilization: float | None = None,
         distribution: ClusterDistributionConfig | None = None,
+        sparkrun_cache_dir: str | None = None,
+        plugins: dict[str, dict[str, Any]] | None = None,
     ) -> None:
         """Create a new named cluster.
 
@@ -595,6 +620,8 @@ class ClusterManager:
             description: Optional cluster description
             user: Optional SSH username for this cluster
             cache_dir: Optional HuggingFace cache directory for this cluster
+            sparkrun_cache_dir: Optional remote sparkrun state/cache root
+            plugins: Optional cluster-local plugin settings
             transfer_mode: Optional transfer mode (local, push, delegated)
             transfer_interface: Optional transfer interface (cx7, mgmt)
             topology: Optional CX7 topology (direct, switch, ring)
@@ -633,6 +660,8 @@ class ClusterManager:
             description=description,
             user=user,
             cache_dir=cache_dir,
+            sparkrun_cache_dir=sparkrun_cache_dir,
+            plugins={name: dict(settings) for name, settings in (plugins or {}).items()},
             transfer_mode=transfer_mode,
             transfer_interface=transfer_interface,
             topology=topology,
@@ -650,6 +679,8 @@ class ClusterManager:
             max_gpu_memory_utilization=max_gpu_memory_utilization,
             distribution=distribution if distribution is not None else ClusterDistributionConfig(),
         )
+        for plugin in cluster_def.plugins:
+            cluster_def.plugin_settings(plugin)
         self._write_cluster(cluster_def)
         logger.info("Created cluster '%s' with %d hosts", name, len(hosts))
 
@@ -692,6 +723,8 @@ class ClusterManager:
         scheduler: str | None = _UNSET,
         max_gpu_memory_utilization: float | None = _UNSET,
         distribution: ClusterDistributionConfig | None = _UNSET,
+        sparkrun_cache_dir: str | None = _UNSET,
+        plugins: dict[str, dict[str, Any]] | None = _UNSET,
     ) -> None:
         """Update existing cluster definition.
 
@@ -701,6 +734,10 @@ class ClusterManager:
             description: New description (if provided)
             user: SSH username (if provided; pass ``None`` explicitly to clear)
             cache_dir: HuggingFace cache directory (if provided; pass ``None`` explicitly to clear)
+            sparkrun_cache_dir: Remote sparkrun state/cache root (if provided;
+                pass ``None`` explicitly to clear)
+            plugins: Cluster-local plugin settings (if provided; pass an empty
+                mapping to clear)
             transfer_mode: Transfer mode (if provided; pass ``None`` explicitly to clear)
             transfer_interface: Transfer interface (if provided; pass ``None`` explicitly to clear)
             topology: CX7 topology (if provided; pass ``None`` explicitly to clear)
@@ -733,6 +770,16 @@ class ClusterManager:
         if cache_dir is not _UNSET:
             cluster_def.cache_dir = cache_dir
             logger.debug("Updated cache_dir for cluster '%s'", name)
+
+        if sparkrun_cache_dir is not _UNSET:
+            cluster_def.sparkrun_cache_dir = sparkrun_cache_dir
+            logger.debug("Updated sparkrun_cache_dir for cluster '%s'", name)
+
+        if plugins is not _UNSET:
+            cluster_def.plugins = {plugin: dict(settings) for plugin, settings in (plugins or {}).items()}
+            for plugin in cluster_def.plugins:
+                cluster_def.plugin_settings(plugin)
+            logger.debug("Updated plugin settings for cluster '%s'", name)
 
         if transfer_mode is not _UNSET:
             if transfer_mode is not None and transfer_mode not in VALID_TRANSFER_MODES:
@@ -904,6 +951,10 @@ class ClusterManager:
             data["user"] = cluster_def.user
         if cluster_def.cache_dir is not None:
             data["cache_dir"] = cluster_def.cache_dir
+        if cluster_def.sparkrun_cache_dir is not None:
+            data["sparkrun_cache_dir"] = cluster_def.sparkrun_cache_dir
+        if cluster_def.plugins:
+            data["plugins"] = {name: dict(settings) for name, settings in cluster_def.plugins.items()}
         if cluster_def.transfer_mode is not None:
             data["transfer_mode"] = cluster_def.transfer_mode
         if cluster_def.transfer_interface is not None:
@@ -982,6 +1033,17 @@ class ClusterManager:
         raw_env = data.get("env") or {}
         cluster_env: dict[str, str] = {str(k): str(v) for k, v in raw_env.items()} if isinstance(raw_env, dict) else {}
 
+        raw_plugins = data.get("plugins") or {}
+        plugins: dict[str, dict[str, Any]] = {}
+        if not isinstance(raw_plugins, dict):
+            raise ClusterError("cluster plugins must be a mapping")
+        for name, settings in raw_plugins.items():
+            if not isinstance(name, str) or not name or not isinstance(settings, dict):
+                raise ClusterError("cluster plugin settings are invalid")
+            if "paths" in settings:
+                raise ClusterError("cluster plugins.%s cannot declare plugin discovery paths" % name)
+            plugins[name] = dict(settings)
+
         accelerator_memory_limits: dict[str, float] = {}
         raw_accel_limits = data.get("accelerator_memory_limits")
         if isinstance(raw_accel_limits, dict):
@@ -997,6 +1059,8 @@ class ClusterManager:
             description=data.get("description", ""),
             user=data.get("user"),
             cache_dir=data.get("cache_dir"),
+            sparkrun_cache_dir=data.get("sparkrun_cache_dir"),
+            plugins=plugins,
             transfer_mode=data.get("transfer_mode"),
             transfer_interface=data.get("transfer_interface"),
             topology=data.get("topology"),

--- a/src/sparkrun/core/external_plugins.py
+++ b/src/sparkrun/core/external_plugins.py
@@ -54,6 +54,8 @@ from sparkrun.core.features import FEATURE_CORE_EXTERNAL_PLUGINS, feature_gate_e
 if TYPE_CHECKING:
     from scitrera_app_framework import Variables
 
+    from sparkrun.core.registry_defaults import DeclarationTier
+
 logger = logging.getLogger(__name__)
 
 # Hard test/CI kill-switch for the config-driven auto-load path — set truthy to
@@ -122,33 +124,48 @@ def _scan_module_for_plugins(module, base: type) -> list[type]:
     return list(found.values())
 
 
-def load_plugin_module(module, v: "Variables") -> None:
+def load_plugin_module(module, v: "Variables", *, tier: "DeclarationTier | None" = None) -> None:
     """Register everything *module* contributes: SAF subclasses, then ``register(v)``.
 
     Shared with :mod:`sparkrun.core.in_tree_plugins` — in-tree and out-of-tree
     plugins differ only in where their modules come from, so they must not
     differ in what counts as a registration.
-    """
-    # 1) Register SAF-scanned plugin subclasses (runtimes/executors/transports/…).
-    for base in _plugin_base_types():
-        for cls in _scan_module_for_plugins(module, base):
-            if not _is_registerable(cls):
-                continue
-            try:
-                register_plugin(cls, v=v)
-                logger.debug("Registered external plugin %s from %s", cls.__name__, module.__name__)
-            except (ValueError, TypeError) as e:
-                logger.debug("Skipping external plugin %s: %s", cls.__name__, e)
 
-    # 2) Optional explicit hook — the home for in-process registrations
-    #    (register_platform, collective backends) and any bespoke wiring.
-    hook = getattr(module, "register", None)
-    if callable(hook):
-        try:
-            hook(v)
-            logger.debug("Ran register(v) hook for external plugin module %s", module.__name__)
-        except Exception:  # noqa: BLE001 - a bad third-party hook must not crash startup
-            logger.exception("register(v) hook failed for external plugin module %s", module.__name__)
+    Args:
+        module: The imported plugin module or package.
+        v: The initialized SAF :class:`~scitrera_app_framework.Variables`.
+        tier: Provenance to attribute this module's registry declarations to
+            (see :mod:`sparkrun.core.registry_defaults`).  Supplied by the
+            *loader* because a plugin must not be able to claim its own tier —
+            an in-tree tier is what lets a declaration ship trusted.  Ambient
+            for the duration of the load rather than an argument, since the
+            plugin makes the registration call, not us.  Defaults to
+            ``OUT_OF_TREE``: least privilege.
+    """
+    from sparkrun.core.registry_defaults import DeclarationTier, declaring_tier
+
+    with declaring_tier(tier or DeclarationTier.OUT_OF_TREE):
+        # 1) Register SAF-scanned plugin subclasses (runtimes/executors/transports/…).
+        for base in _plugin_base_types():
+            for cls in _scan_module_for_plugins(module, base):
+                if not _is_registerable(cls):
+                    continue
+                try:
+                    register_plugin(cls, v=v)
+                    logger.debug("Registered external plugin %s from %s", cls.__name__, module.__name__)
+                except (ValueError, TypeError) as e:
+                    logger.debug("Skipping external plugin %s: %s", cls.__name__, e)
+
+        # 2) Optional explicit hook — the home for in-process registrations
+        #    (register_platform, collective backends, register_default_registry)
+        #    and any bespoke wiring.
+        hook = getattr(module, "register", None)
+        if callable(hook):
+            try:
+                hook(v)
+                logger.debug("Ran register(v) hook for external plugin module %s", module.__name__)
+            except Exception:  # noqa: BLE001 - a bad third-party hook must not crash startup
+                logger.exception("register(v) hook failed for external plugin module %s", module.__name__)
 
 
 def _configured_paths(v: "Variables") -> list[Path]:

--- a/src/sparkrun/core/in_tree_plugins.py
+++ b/src/sparkrun/core/in_tree_plugins.py
@@ -53,6 +53,7 @@ from typing import TYPE_CHECKING
 
 from sparkrun.core.external_plugins import load_plugin_module
 from sparkrun.core.features import feature_gate_enabled, get_feature
+from sparkrun.core.registry_defaults import DeclarationTier
 
 if TYPE_CHECKING:
     from scitrera_app_framework import Variables
@@ -123,7 +124,11 @@ def load_in_tree_plugins(v: "Variables", package: str = IN_TREE_PLUGIN_PACKAGE) 
             # say so loudly.
             logger.exception("Failed to import in-tree plugin %r", dotted)
             continue
-        load_plugin_module(module, v)
+        # IN_TREE is what lets this plugin's registry declarations ship trusted
+        # (sparkrun.core.registry_defaults). Asserted by the loader, never by
+        # the plugin — including for a vendored plugin, where the claim rests on
+        # the pinned commit in vendor/*.lock and the review of the import PR.
+        load_plugin_module(module, v, tier=DeclarationTier.IN_TREE)
         loaded.append(name)
 
     if loaded:

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -22,6 +22,7 @@ from sparkrun.core.timing import ROOT as TIMELINE_ROOT, STATUS_ERROR, Timeline, 
 
 if TYPE_CHECKING:
     from sparkrun.core.backend_select import BackendBundle
+    from sparkrun.core.cluster_manager import ClusterDefinition
     from sparkrun.core.config import SparkrunConfig
     from sparkrun.core.context import SparkrunContext
     from sparkrun.core.progress import LaunchProgress
@@ -480,6 +481,7 @@ def resolve_effective_runtime_cache_dir(
     ssh_kwargs: dict,
     config: SparkrunConfig,
     dry_run: bool = False,
+    cluster: ClusterDefinition | None = None,
 ) -> str:
     """Resolve the target hosts' sparkrun cache dir for the runtime cache.
 
@@ -490,6 +492,10 @@ def resolve_effective_runtime_cache_dir(
     cache is an optimization, and a wrong guess costs a recompile (the
     directory simply won't pre-exist) while an exception would cost the launch.
     """
+    configured = getattr(cluster, "sparkrun_cache_dir", None)
+    if configured:
+        return str(configured)
+
     from sparkrun.utils import is_local_host
     from sparkrun.orchestration.primitives import probe_remote_sparkrun_cache
 
@@ -1754,7 +1760,13 @@ def launch_inference(
         if _rc_settings.enabled:
             _rc_root = resolve_runtime_cache_root(
                 _rc_settings,
-                resolve_effective_runtime_cache_dir(host_list, ssh_kwargs, config, dry_run=dry_run),
+                resolve_effective_runtime_cache_dir(
+                    host_list,
+                    ssh_kwargs,
+                    config,
+                    dry_run=dry_run,
+                    cluster=cluster,
+                ),
             )
             # Derived *after* apply_platform_runtime_flag_defaults, deliberately.
             # The fingerprint then reflects the platform flags this hardware

--- a/src/sparkrun/core/launcher.py
+++ b/src/sparkrun/core/launcher.py
@@ -142,9 +142,30 @@ def resolve_recipe_trust(recipe: Recipe, trust_cli: bool) -> bool:
 #: can run the container as root; ``volumes`` bind-mounts host paths.  Honouring
 #: any of these for a "run this link" recipe is a host-takeover primitive, so we
 #: fail closed unless the recipe is trusted.  Innocuous resource knobs
-#: (``shm_size``, ``ipc``, ``network``, ``memory_limit``, ``ulimit``,
-#: ``restart_policy``, ``auto_remove``, ``labels`` …) are intentionally absent.
+#: (``shm_size``, ``network``, ``memory_limit``, ``ulimit``, ``restart_policy``,
+#: ``auto_remove``, ``labels`` …) are intentionally absent.  ``ipc`` is gated on
+#: its *value* instead — see :data:`_UNTRUSTED_IPC_MODES`.
 _TRUST_GATED_EXECUTOR_KEYS = frozenset({"privileged", "cap_add", "security_opt", "devices", "user", "volumes"})
+
+#: ``ipc`` modes an untrusted recipe may select: the ones that put the container
+#: in a **fresh** IPC namespace of its own.  ``""`` is included because an empty
+#: value emits no ``--ipc`` flag at all, leaving Docker's own ``private``.
+#:
+#: This is an allowlist, not a denylist of ``host``, because more than one value
+#: reaches out of the container and the set is open-ended: ``host`` shares the
+#: host's IPC namespace and ``/dev/shm`` (read/write access to every other
+#: tenant's POSIX shared memory and semaphores on that machine, and the ability
+#: to delete them), while ``container:<name>`` joins one specific other
+#: workload's namespace — and sparkrun container names are derivable from a
+#: cluster_id, so that is a targeted lateral read rather than a lucky one.
+#: An unrecognised or non-string value therefore fails closed too.
+#:
+#: This was an ungated resource knob while ``host`` was the default, when
+#: setting it changed nothing.  It is an escalation now that the default is a
+#: container-owned namespace (see ``docker.DOCKER_IPC_DEFAULT``): an untrusted
+#: recipe asking for ``host`` is asking to leave the sandbox it was granted.
+#: Narrowing it (``shareable`` → ``private``) stays free, as it should.
+_UNTRUSTED_IPC_MODES = frozenset({"", "none", "private", "shareable"})
 
 #: Executors an untrusted recipe is allowed to select.  Only the Docker executor
 #: runs the workload inside a rootless, namespaced container — the sandbox that
@@ -168,7 +189,10 @@ def _enforce_recipe_mount_trust(recipe: Recipe, trusted: bool) -> None:
       ``privileged``/``cap_add``/``security_opt``/``devices``/``user``/``volumes``.
       These sit *above* the executor's rootless ``apply_runtime_adjustments``
       layer in :func:`resolve_executor`'s chain, so a recipe that sets them wins
-      over the hardening (e.g. ``privileged: true`` → ``docker run --privileged``).
+      over the hardening (e.g. ``privileged: true`` → ``docker run --privileged``);
+    * ``executor_config.ipc``, gated on its **value** rather than its presence
+      (:data:`_UNTRUSTED_IPC_MODES`) — narrowing the namespace is free, leaving
+      it for the host's or another container's is not.
 
     All are infra-level escape hatches.  Honouring them for an untrusted
     (registry- or URL-sourced) recipe would let "run this link" mount ``/``,
@@ -220,6 +244,20 @@ def _enforce_recipe_mount_trust(recipe: Recipe, trusted: bool) -> None:
                 "raw --device access, or running as root). They are only honoured "
                 "for trusted recipes; re-run with --trust after auditing this "
                 "recipe." % gated
+            )
+
+        # ``ipc`` is gated on its value, not its presence: a recipe may narrow
+        # the namespace freely, but reaching *out* of the container's own is an
+        # escalation. See _UNTRUSTED_IPC_MODES.
+        raw_ipc = exec_cfg.get("ipc")
+        if raw_ipc is not None and str(raw_ipc).strip().lower() not in _UNTRUSTED_IPC_MODES:
+            raise RecipeError(
+                "This recipe sets executor_config ipc=%r, which places the workload "
+                "outside its own IPC namespace — sharing the host's /dev/shm (every "
+                "other tenant's POSIX shared memory and semaphores on that machine), "
+                "or joining another container's. Only %s are honoured for untrusted "
+                "recipes; re-run with --trust after auditing this recipe."
+                % (raw_ipc, ", ".join(sorted(m for m in _UNTRUSTED_IPC_MODES if m)))
             )
 
     # The executor *selector* is itself an isolation control: only ``docker``

--- a/src/sparkrun/core/progress.py
+++ b/src/sparkrun/core/progress.py
@@ -30,9 +30,10 @@ import logging
 import re
 import threading
 import time
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from enum import IntEnum
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from sparkrun.core.timing import Timeline
@@ -52,7 +53,11 @@ DEFAULT_HEARTBEAT_SECONDS = 30.0
 
 
 @contextmanager
-def progress_heartbeat(logger: logging.Logger, label: str, interval: float = DEFAULT_HEARTBEAT_SECONDS) -> Iterator[None]:
+def progress_heartbeat(
+    logger: logging.Logger,
+    label: str | Callable[[], str],
+    interval: float = DEFAULT_HEARTBEAT_SECONDS,
+) -> Iterator[None]:
     """Keep a long operation visibly alive at the standard progress level.
 
     For work that emits nothing while it runs — a multi-minute image build, a
@@ -65,7 +70,8 @@ def progress_heartbeat(logger: logging.Logger, label: str, interval: float = DEF
 
     def report() -> None:
         while not stopped.wait(interval):
-            logger.log(PROGRESS, "%s — still running (%.0fs)", label, time.monotonic() - started)
+            current_label = label() if callable(label) else label
+            logger.log(PROGRESS, "%s — still running (%.0fs)", current_label, time.monotonic() - started)
 
     thread = threading.Thread(target=report, name="sparkrun-progress-heartbeat", daemon=True)
     thread.start()

--- a/src/sparkrun/core/recipe.py
+++ b/src/sparkrun/core/recipe.py
@@ -1294,15 +1294,29 @@ class Recipe:
     def build_config_chain(self, cli_overrides: dict[str, Any] | None = None, user_config: dict[str, Any] | None = None) -> Variables:
         """Build cascading config: CLI overrides -> user config -> recipe defaults.
 
-        Also injects ``model`` and ``resolved_model_path`` into the chain for
-        ``{...}`` template substitution.  ``resolved_model_path`` resolves to the
-        recipe's ``cluster_config.resolved_model_path`` when set (pre-placed
-        on-disk weights), otherwise falls back to ``model`` so the same template
+        Also injects ``model``, ``model_revision`` and ``resolved_model_path``
+        into the chain for ``{...}`` template substitution.
+        ``resolved_model_path`` resolves to the recipe's
+        ``cluster_config.resolved_model_path`` when set (pre-placed on-disk
+        weights), otherwise falls back to ``model`` so the same template
         — e.g. ``--chat-template {resolved_model_path}/chat_template.jinja`` —
         works for both the override and normal cases.
+
+        ``model_revision`` is injected **only when the recipe pins one**, so a
+        template that references it and a recipe that forgot the pin still emit
+        a literal ``{model_revision}``.  That is deliberate: an unguarded
+        injection would render ``--revision None``, which looks like a valid
+        argument and fails inside the engine on a revision that does not exist,
+        rather than failing visibly as an unsubstituted placeholder.  Engines
+        need the pin passed through explicitly — sparkrun downloads by raw
+        commit SHA, which writes no ``refs/`` entry in the HuggingFace cache,
+        and the container runs ``HF_HUB_OFFLINE=1`` (see
+        :func:`sparkrun.core.validation.check_unpinned_model_revision`).
         """
         base = dict(self.defaults)
         base.setdefault("model", self.model)
+        if self.model_revision:
+            base.setdefault("model_revision", self.model_revision)
         _rmp = getattr(getattr(self, "cluster_config", None), "resolved_model_path", None)
         base.setdefault("resolved_model_path", _rmp or self.model)
         return Variables(sources=(cli_overrides or {}, user_config or {}, base), env_placement=EnvPlacement.IGNORED)

--- a/src/sparkrun/core/registry.py
+++ b/src/sparkrun/core/registry.py
@@ -135,6 +135,15 @@ class RegistryEntry:
             confirmation prompt.  Defaults to False so user-added third-party
             registries are untrusted until explicitly opted-in via
             ``sparkrun registry trust <name>`` or ``registry add --trust``.
+        declared_by: Name of the plugin that declared this registry, or ``""``
+            for an ordinary user-owned entry read from ``registries.yaml``.
+            **Runtime-only and never serialized** — see
+            :mod:`sparkrun.core.registry_defaults`.  A declared entry is an
+            overlay: it exists while its plugin is loaded and is not written to
+            the config file, which is what makes uninstalling a plugin remove
+            its registries cleanly.  Mutating one (``registry disable`` /
+            ``trust`` / ``untrust``) *materializes* it by clearing this field,
+            after which it is an ordinary file entry the user owns.
     """
 
     name: str
@@ -147,6 +156,7 @@ class RegistryEntry:
     benchmark_subpath: str = ""
     mods_subpath: str = ""
     trusted: bool = False
+    declared_by: str = ""
 
 
 #: Asset subpaths a registry may omit.  Shared with
@@ -466,6 +476,15 @@ def _normalize_registry_url(url: str) -> str:
 #: migrating".
 CONFIG_VERSION = 1
 
+#: Top-level ``registries.yaml`` key holding names the user removed that a
+#: plugin still declares (see :meth:`RegistryManager._load_suppressed`).
+#:
+#: Additive: an older sparkrun ignores an unknown top-level key, and the overlay
+#: is not a file rewrite, so this needs no :data:`CONFIG_VERSION` bump.  Per the
+#: :data:`_MIGRATIONS` docstring, only migrations that cannot detect their own
+#: applicability from file content belong there.
+SUPPRESSED_REGISTRIES_KEY = "suppressed_plugin_registries"
+
 #: Version implied by a file that carries no ``config_version`` key but does
 #: carry an explicit per-entry ``trusted`` field — i.e. one written after the
 #: trust model landed but before the marker did.
@@ -598,6 +617,15 @@ RESERVED_PREFIX_ALLOWED_ORGS = (
 # which lowercases the URL path component before returning.
 EXTERNAL_RESERVED_NAMES = {
     "atlas": ("atlas-inf",),
+    # ColdSnap's recipe registries, declared by the in-tree ColdSnap plugin (see
+    # sparkrun.core.registry_defaults).  Exact-match rather than a
+    # RESERVED_NAME_PREFIXES entry on purpose: RESERVED_PREFIX_ALLOWED_ORGS is a
+    # *global* allowlist, so covering "coldsnap-*" that way would also grant
+    # sparksq every other reserved prefix (official-*, sparkrun-*, arena-*).
+    # That may be a reasonable thing to decide later; it is not a side effect
+    # this reservation should smuggle in.
+    "coldsnap": ("sparksq",),
+    "coldsnap-vanilla": ("sparksq",),
 }
 
 
@@ -1049,6 +1077,93 @@ class RegistryManager:
         """Get the recipe directory within a cached registry."""
         return self.asset_dir(entry, RECIPE_ASSET)
 
+    def _load_suppressed(self) -> list[str]:
+        """Names the user removed that a plugin still declares (tombstones).
+
+        ``registry remove`` on a declared registry cannot simply drop it — the
+        declaration would put it straight back on the next launch, which is
+        indistinguishable from a bug.  So the removal is recorded here instead.
+        Kept as a plain list under :data:`SUPPRESSED_REGISTRIES_KEY` in
+        ``registries.yaml``; an older sparkrun ignores the key.
+        """
+        if not self._registries_path.exists():
+            return []
+        try:
+            data = read_yaml(self._registries_path)
+        except Exception:
+            return []
+        if not isinstance(data, dict):
+            return []
+        raw = data.get(SUPPRESSED_REGISTRIES_KEY) or []
+        if not isinstance(raw, list):
+            return []
+        return [str(name) for name in raw if isinstance(name, str) and name]
+
+    def _apply_plugin_overlay(self, entries: list[RegistryEntry]) -> list[RegistryEntry]:
+        """Merge plugin-declared registries onto the user's own entries.
+
+        Applied *after* every convergent rewrite and after any save, so declared
+        entries never enter the migration or persistence path — the overlay is
+        computed fresh on each load and only the user's file is durable.
+
+        Resolution, in order:
+
+        1. **A collision with a shipped default is refused and warned.**  The
+           declaration loses.  Refusing rather than ranking is deliberate: the
+           legitimate use of this seam is contributing a *new* name, and letting
+           a declaration silently shadow a curated one would be a namespace
+           redirect that ``validate_registry_name`` cannot catch (it only guards
+           *reserved* names).  Pathological, so make it loud.
+
+           Checked **first**, before the file-entry rule below, precisely so it
+           is loud in the common case too: a shipped default is normally present
+           in the user's file, so an ordering that let rule 2 match first would
+           silently ignore a plugin trying to redefine ``official`` — the one
+           case most worth reporting.
+        2. **A file entry of the same name wins outright, silently.**  That is
+           the supported override (materialize-on-mutation puts entries there,
+           and it is how a user repoints a declared registry at an internal
+           mirror), so it is a normal outcome, not a conflict.
+        3. **A tombstone suppresses**, likewise silently — the user said no.
+        """
+        from sparkrun.core.registry_defaults import iter_declared_registries
+
+        declarations = iter_declared_registries()
+        if not declarations:
+            return entries
+
+        existing = {e.name for e in entries}
+        suppressed = set(self._load_suppressed())
+        shipped = {e.name for e in FALLBACK_DEFAULT_REGISTRIES}
+
+        merged = list(entries)
+        for declaration in declarations:
+            name = declaration.entry.name
+            if name in shipped:
+                logger.warning(
+                    "Plugin %r declares registry %r, which is a shipped default; ignoring the declaration",
+                    declaration.owner,
+                    name,
+                )
+                continue
+            if name in existing:
+                logger.debug(
+                    "Registry %r is configured locally; ignoring the declaration from plugin %r",
+                    name,
+                    declaration.owner,
+                )
+                continue
+            if name in suppressed:
+                logger.debug(
+                    "Registry %r declared by plugin %r was removed by the user; not re-adding",
+                    name,
+                    declaration.owner,
+                )
+                continue
+            merged.append(declaration.effective_entry())
+            existing.add(name)
+        return merged
+
     def _default_registries(self) -> list[RegistryEntry]:
         """Return the default registry list.
 
@@ -1087,11 +1202,13 @@ class RegistryManager:
                 combined.append(_dataclass_replace(fallback))
                 seen_names.add(fallback.name)
 
-        # Persist so subsequent _load_registries() reads from file
+        # Persist so subsequent _load_registries() reads from file.  The overlay
+        # is applied *after* this, so a declared registry is never written into
+        # a fresh registries.yaml either.
         if discovered:
             self._save_registries(combined)
 
-        return combined
+        return self._apply_plugin_overlay(combined)
 
     def _init_defaults_from_manifests(self) -> list[RegistryEntry]:
         """Try to discover default registries from git manifest files.
@@ -1415,19 +1532,38 @@ class RegistryManager:
 
             if migrated or urls_migrated or subpaths_backfilled:
                 self._save_registries(filtered)
-            return filtered
+            # Overlay last: declared entries must not reach the rewrite or save
+            # path above, or a plugin's registry would be persisted into the
+            # user's file and outlive the plugin.
+            return self._apply_plugin_overlay(filtered)
         except Exception as e:
             logger.warning("Failed to load registries.yaml: %s", e)
             return self._default_registries()
 
-    def _save_registries(self, entries: list[RegistryEntry]) -> None:
+    def _save_registries(self, entries: list[RegistryEntry], *, suppressed: list[str] | None = None) -> None:
         """Save registries to YAML configuration.
 
+        Plugin-declared entries (``declared_by`` set) are **skipped**.  Every
+        mutating command reads through :meth:`_load_registries`, which now
+        includes the overlay, and each of them rewrites the whole document — so
+        without this filter the first ``registry disable`` of anything would
+        quietly persist every declared registry, and they would then outlive
+        their plugin.  Materializing one is done by *clearing* ``declared_by``
+        (see :meth:`_materialize_declared`), which is what lets it through here.
+
         Args:
-            entries: List of registry entries to save
+            entries: Registry entries to save; declared entries are ignored.
+            suppressed: Tombstone list to write.  ``None`` preserves whatever is
+                already on disk — this method rebuilds the document from
+                scratch, so anything not re-emitted is dropped.
         """
+        if suppressed is None:
+            suppressed = self._load_suppressed()
+
         data_list = []
         for e in entries:
+            if e.declared_by:
+                continue
             d: dict[str, Any] = {"name": e.name, "url": e.url, "subpath": e.subpath}
             if e.description:
                 d["description"] = e.description
@@ -1456,7 +1592,9 @@ class RegistryManager:
         # Stamped on every write, not just by the migration runner: this method
         # rebuilds the document from scratch, so anything it didn't re-emit
         # would be silently dropped.
-        data = {"config_version": CONFIG_VERSION, "registries": data_list}
+        data: dict[str, Any] = {"config_version": CONFIG_VERSION, "registries": data_list}
+        if suppressed:
+            data[SUPPRESSED_REGISTRIES_KEY] = sorted(set(suppressed))
         with open(self._registries_path, "w") as f:
             yaml.dump(data, f, default_flow_style=False, sort_keys=False)
         logger.debug("Saved registries to %s", self._registries_path)
@@ -1834,7 +1972,12 @@ class RegistryManager:
         if any(r.name == entry.name for r in registries):
             raise RegistryError(f"Registry {entry.name!r} already exists")
         registries.append(entry)
-        self._save_registries(registries)
+        # Adding a name back is an explicit reversal of a prior removal, so it
+        # clears any tombstone.  Otherwise a user who removed a plugin-declared
+        # registry and later re-added it under their own URL would keep a
+        # suppression entry that silences the declaration forever, invisibly.
+        suppressed = [name for name in self._load_suppressed() if name != entry.name]
+        self._save_registries(registries, suppressed=suppressed)
         logger.info("Added registry %s", entry.name)
 
     def _discover_manifest_entries(self, url: str) -> list[RegistryEntry]:
@@ -1970,8 +2113,32 @@ class RegistryManager:
                 entry.trusted = True
         return added
 
+    @staticmethod
+    def _materialize_declared(entry: RegistryEntry) -> None:
+        """Turn a plugin-declared entry into a user-owned one, in place.
+
+        Clearing ``declared_by`` is what lets :meth:`_save_registries` write it.
+        After this the file entry wins over the declaration
+        (:meth:`_apply_plugin_overlay` rule 1), so the user's change is durable
+        and survives the plugin being upgraded, disabled or removed — which is
+        the point: they took ownership of it.
+        """
+        if entry.declared_by:
+            logger.info(
+                "Registry %r was declared by plugin %r; saving it to your configuration so this change persists",
+                entry.name,
+                entry.declared_by,
+            )
+            entry.declared_by = ""
+
     def remove_registry(self, name: str) -> None:
         """Remove a registry by name.
+
+        A plugin-declared registry is **tombstoned** rather than deleted: it is
+        not in ``registries.yaml`` to remove, and dropping it from the in-memory
+        list would let the declaration put it straight back on the next launch —
+        a removal that silently fails to remove. The tombstone is cleared by
+        adding the registry back (:meth:`add_registry`).
 
         Args:
             name: Registry name to remove
@@ -1980,9 +2147,23 @@ class RegistryManager:
             RegistryError: If the registry is not found
         """
         registries = self._load_registries()
-        filtered = [r for r in registries if r.name != name]
-        if len(filtered) == len(registries):
+        target = next((r for r in registries if r.name == name), None)
+        if target is None:
             raise RegistryError(f"Registry {name!r} not found")
+
+        filtered = [r for r in registries if r.name != name]
+        if target.declared_by:
+            suppressed = self._load_suppressed()
+            if name not in suppressed:
+                suppressed.append(name)
+            self._save_registries(filtered, suppressed=suppressed)
+            logger.info(
+                "Removed registry %s (declared by plugin %r; suppressed so it is not re-added)",
+                name,
+                target.declared_by,
+            )
+            return
+
         self._save_registries(filtered)
         logger.info("Removed registry %s", name)
 
@@ -2140,6 +2321,7 @@ class RegistryManager:
         for e in entries:
             if e.name == name:
                 e.enabled = enabled
+                self._materialize_declared(e)
                 self._save_registries(entries)
                 logger.info("%s registry %s", "Enabled" if enabled else "Disabled", name)
                 return
@@ -2175,6 +2357,7 @@ class RegistryManager:
         for e in entries:
             if e.name == name:
                 e.trusted = trusted
+                self._materialize_declared(e)
                 self._save_registries(entries)
                 logger.info("%s registry %s", "Trusted" if trusted else "Untrusted", name)
                 return

--- a/src/sparkrun/core/registry_defaults.py
+++ b/src/sparkrun/core/registry_defaults.py
@@ -1,0 +1,227 @@
+"""Registries a plugin declares should exist while it is loaded.
+
+The shipped defaults (:data:`sparkrun.core.registry.BOOTSTRAP_REGISTRY_URLS` and
+:data:`~sparkrun.core.registry.FALLBACK_DEFAULT_REGISTRIES`) are closed
+constants.  This module is the extension point beside them: a plugin whose
+recipes are inert without it — ColdSnap is the first — declares its registry
+here, and it becomes resolvable (``@coldsnap/<recipe>``) for anyone with the
+plugin enabled, without the user adding anything.
+
+An **in-process** registry, like :mod:`sparkrun.platforms` and
+:func:`sparkrun.models.kv.register_kv_strategy`, rather than a SAF extension
+point: registration must be cheap (it runs on every CLI invocation, including
+shell completion — see below), ordered by the plugin loader, and reachable from
+a plugin's ``register(v)`` hook.
+
+**Registration performs no I/O.**  It records intent and validates; nothing is
+cloned, read or written.  This is not a nicety: shell completion runs
+``init_sparkrun`` on every ``<TAB>`` (Click resolves the command tree through
+``PluggableGroup.get_command``), so anything expensive here lands on the
+interactive path.  It is also why a plugin cannot point at a remote manifest and
+have its *names* come from there — the overlay has to be computable offline.
+
+**Declarations are an overlay, never persisted.**  ``RegistryManager`` merges
+them into the list it loads; ``registries.yaml`` keeps only what the user owns.
+So uninstalling or disabling a plugin removes its registries with it, and there
+is no orphaned entry to reap.  User decisions still stick — mutating a declared
+registry (``registry disable`` / ``trust`` / ``untrust``) *materializes* it into
+the file, after which the file wins; ``registry remove`` records a tombstone.
+
+Tier
+----
+:class:`DeclarationTier` records **who vouches for** a declaration, and decides
+whether a ``trusted=True`` claim is honored (see
+:meth:`DeclaredRegistry.effective_entry`).  It is supplied by the **loader**,
+never by the plugin: ``load_plugin_module`` wraps registration in
+:func:`declaring_tier`, and a call made outside any loader is treated as
+``OUT_OF_TREE`` — least privilege, so nothing can acquire in-tree trust by
+registering from an unexpected place.
+
+(The design note originally proposed threading the tier as an explicit argument.
+That is not implementable: the *plugin* makes the call, so the loader has no
+argument to thread — the value has to be ambient for the duration of the load.)
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, replace as _dataclass_replace
+from enum import Enum
+from typing import Iterator
+
+from sparkrun.core.registry import (
+    RegistryEntry,
+    RegistryError,
+    assert_safe_registry_entry,
+    validate_registry_name,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DeclarationTier(Enum):
+    """Provenance of a plugin declaration."""
+
+    #: Ships inside the sparkrun distribution (``sparkrun.plugins.*``), whether
+    #: authored here or vendored in under ``vendor/*.lock``.
+    IN_TREE = "in-tree"
+
+    #: Loaded from a user-configured ``plugins.paths`` directory.
+    OUT_OF_TREE = "out-of-tree"
+
+
+#: Ambient tier for the duration of a plugin load.  ``OUT_OF_TREE`` is the
+#: default because it is the *less* privileged of the two: a declaration made
+#: outside a loader — a stray import, a test, a plugin calling in from a thread
+#: — must not be able to obtain in-tree trust by accident.
+_ACTIVE_TIER: ContextVar[DeclarationTier] = ContextVar(
+    "sparkrun_declaring_tier",
+    default=DeclarationTier.OUT_OF_TREE,
+)
+
+
+@contextmanager
+def declaring_tier(tier: DeclarationTier) -> Iterator[None]:
+    """Mark declarations made inside this block as coming from *tier*.
+
+    Used by the plugin loaders (:mod:`sparkrun.core.in_tree_plugins`,
+    :mod:`sparkrun.core.external_plugins`); plugins do not call this.
+    """
+    token = _ACTIVE_TIER.set(tier)
+    try:
+        yield
+    finally:
+        _ACTIVE_TIER.reset(token)
+
+
+@dataclass(frozen=True)
+class DeclaredRegistry:
+    """One registry a plugin declared, plus who declared it."""
+
+    entry: RegistryEntry
+    owner: str
+    tier: DeclarationTier
+
+    def effective_entry(self) -> RegistryEntry:
+        """A private copy of the entry, with trust resolved by tier.
+
+        An **in-tree** declaration may ship ``trusted=True``: it arrives through
+        the same review and release gate as the shipped defaults (and, when
+        vendored, through a pinned commit with per-file digests), so declaring
+        it trusted is the same act as adding a trusted entry to
+        ``FALLBACK_DEFAULT_REGISTRIES``.
+
+        An **out-of-tree** declaration is forced untrusted.  Installing a plugin
+        says "I want this capability"; it does not say "I grant its recipe repo
+        standing permission to run lifecycle hooks from whatever it contains
+        next month".  Those are separable, and the user grants the second
+        explicitly with ``sparkrun registry trust <name>`` — which materializes
+        the entry, so it sticks.
+
+        The copy matters: callers mutate what they are handed (``trust_registry``
+        flips ``trusted``, ``disable_registry`` flips ``enabled``), and this is
+        the only source of these entries, so aliasing would let one invocation
+        rewrite the declaration process-wide.
+        """
+        trusted = bool(self.entry.trusted) and self.tier is DeclarationTier.IN_TREE
+        if self.entry.trusted and not trusted:
+            logger.debug(
+                "Ignoring trusted=True on registry %r declared by out-of-tree plugin %r; run 'sparkrun registry trust %s' to grant it",
+                self.entry.name,
+                self.owner,
+                self.entry.name,
+            )
+        return _dataclass_replace(self.entry, trusted=trusted, declared_by=self.owner)
+
+
+#: name -> declaration.  Keyed by name because a name is what collides.
+_DECLARED: dict[str, DeclaredRegistry] = {}
+
+
+def register_default_registry(entry: RegistryEntry, *, owner: str) -> None:
+    """Declare a registry that should exist while *owner* is loaded.
+
+    Args:
+        entry: The registry to contribute.  ``enabled`` / ``visible`` / trusted
+            are honored subject to the tier rules above.
+        owner: The declaring plugin's name.  Required and non-blank.
+
+    Raises:
+        ValueError: If *owner* is blank.
+        RegistryError: If the name or a subpath is unsafe, the name impersonates
+            a reserved namespace, or a *different* owner already declared it.
+
+    Registration is idempotent for the same owner and an equal entry, so a
+    re-imported plugin module is harmless.  A second owner claiming the same
+    name raises — mirroring :func:`sparkrun.core.recipe_items.register_recipe_item`,
+    because two plugins silently reinterpreting one registry name has no correct
+    arbitration.
+
+    Validation runs **here**, at the declaration's own call site, rather than
+    where the overlay is applied — a plugin is local code we can fix, unlike a
+    hostile remote manifest that must be survived, so this raises instead of
+    dropping the entry.
+    """
+    if not owner or not owner.strip():
+        raise ValueError("plugin registry declaration requires a non-blank owner")
+
+    # Both guards are mandatory: a name becomes a directory under the cache root
+    # (and _link_registry_to_shared rmtree()s a non-link cache dir, making an
+    # escaping name a delete primitive), and a subpath becomes a path inside it
+    # whose contents are offered to the recipe loader.
+    validate_registry_name(entry.name, entry.url)
+    assert_safe_registry_entry(entry)
+
+    declaration = DeclaredRegistry(entry=entry, owner=owner, tier=_ACTIVE_TIER.get())
+
+    existing = _DECLARED.get(entry.name)
+    if existing is not None:
+        if existing.owner == owner and existing.entry == entry:
+            return
+        if existing.owner != owner:
+            raise RegistryError("registry %r is already declared by plugin %r" % (entry.name, existing.owner))
+    _DECLARED[entry.name] = declaration
+    logger.debug(
+        "Plugin %r declared %s registry %r -> %s",
+        owner,
+        declaration.tier.value,
+        entry.name,
+        entry.url,
+    )
+
+
+def iter_declared_registries() -> tuple[DeclaredRegistry, ...]:
+    """Every current declaration, ordered by owner then name.
+
+    Deterministic rather than insertion-ordered so the overlay a user sees does
+    not depend on plugin load order.
+    """
+    return tuple(sorted(_DECLARED.values(), key=lambda d: (d.owner, d.entry.name)))
+
+
+def declared_registry_names() -> frozenset[str]:
+    """Names currently declared by a plugin."""
+    return frozenset(_DECLARED)
+
+
+def reset_declared_registries() -> None:
+    """Drop every declaration.
+
+    Process-global state, so the test suite must reset it between tests exactly
+    as it resets the bootstrap ``_variables`` singleton — otherwise one test's
+    declaration leaks into every later test's registry list.
+    """
+    _DECLARED.clear()
+
+
+__all__ = [
+    "DeclarationTier",
+    "DeclaredRegistry",
+    "declared_registry_names",
+    "declaring_tier",
+    "iter_declared_registries",
+    "register_default_registry",
+    "reset_declared_registries",
+]

--- a/src/sparkrun/core/validation.py
+++ b/src/sparkrun/core/validation.py
@@ -597,20 +597,33 @@ _SIGNALS_NOT_IN_DEFAULTS = frozenset({"a write into the installed package tree"}
 
 
 def check_inline_scripting(recipe: Recipe) -> list[RecipeIssue]:
-    """Suggest ``mods:`` when a recipe carries a program instead of a command.
+    """Report a recipe that carries a program rather than a command.
 
     A recipe that patches its own container — a heredoc'd Python program that
     rewrites vLLM's source, a ``sed -i`` over the installed package, a
-    ``pip install`` before the serve line — is doing what ``mods:`` exists for,
-    and the difference is not stylistic.  A mod is a directory with a
-    ``run.sh``; sparkrun ``docker cp``s it into the container and runs it
-    before the serve command, so the script is a **file** that travels with the
-    recipe through its registry, can be reviewed and diffed on its own, and is
-    copied **verbatim**.
+    ``pip install`` before the serve line — is building an image at launch
+    time, one node at a time, out of a string.  There are **two** supported
+    ways to express the same thing, and the finding names both as peers rather
+    than steering to one:
 
-    That last property is the sparkrun-specific argument, because the three
-    places a script can live are rendered differently and only one of them
-    leaves it alone:
+    * **A custom container image.**  The change is applied once, at build time,
+      by the tooling built for it; the result is content-addressed, pullable,
+      and shared by every node.  This is the better answer whenever the change
+      is stable or expensive — a package install, a compiled extension, a patch
+      that will outlive one recipe.  It costs a registry to publish to.
+    * **A ``mods:`` entry.**  A directory with a ``run.sh`` that sparkrun
+      ``docker cp``s into the container and runs before the serve command.  The
+      better answer when publishing an image is not practical or the change is
+      small and recipe-specific: it travels with the recipe through its
+      registry and needs no build infrastructure.  It still runs per node per
+      launch — that cost is inherent to patching at runtime and is *not* what
+      this finding is about.
+
+    What both buy over inlining is that the script becomes a **file**: it can
+    be reviewed and diffed on its own, and it is never passed through the
+    placeholder renderer.  That second property is the sparkrun-specific
+    argument, because the places a script can live are rendered differently and
+    only the file forms leave it alone:
 
     * ``command:`` goes through ``Recipe.render_command``, whose brace-escape
       mode is inferred *from the template itself*
@@ -623,7 +636,8 @@ def check_inline_scripting(recipe: Recipe) -> list[RecipeIssue]:
       does *not* collapse ``{{`` but does still substitute ``{name}`` — so a
       program is safe from the escaping rule and still exposed to a collision
       with any config-chain key it happens to spell.
-    * a mod's ``run.sh`` is never rendered at all.
+    * a mod's ``run.sh`` — and anything baked into the image — is never
+      rendered at all.
 
     A suggestion, not a warning: an inline patch runs identically on every
     cluster, so nothing here breaks somewhere else — what is given up is
@@ -652,15 +666,18 @@ def check_inline_scripting(recipe: Recipe) -> list[RecipeIssue]:
             RecipeIssue(
                 SUGGESTION,
                 "inline-script",
-                "%s: contains %s. A recipe that patches or installs into its own container is doing what `mods:` "
-                "exists for. Inline, the program is re-run on every node on every launch, cannot be reviewed or "
-                "diffed apart from the recipe, and — in `command:` — is passed through the placeholder renderer, "
-                "so every literal brace in it has to be escaped and one missed brace mis-renders the program "
-                "silently." % (where, ", ".join(evidence)),
-                "Move it to a `mods:` entry — a directory with a `run.sh`, copied into the container verbatim "
-                "and run before the serve command, which travels with the recipe through its registry and is "
-                "never passed through the renderer. For a package install, prefer baking it into the container "
-                "image so it is not repeated on every launch.",
+                "%s: contains %s — the recipe is patching or installing into its own container from a string. "
+                "Inline, the change cannot be reviewed or diffed apart from the recipe, and — in `command:` — it "
+                "is passed through the placeholder renderer, so every literal brace in it has to be escaped and "
+                "one missed brace mis-renders the program silently." % (where, ", ".join(evidence)),
+                "Two supported ways to express this, both of which make the change a file rather than a string, "
+                "and neither of which goes through the renderer. (1) Publish a custom container image with the "
+                "change built in and name it in `container:` — best when the change is stable or expensive to "
+                "apply, since it happens once at build time and every node pulls the result. (2) Add a `mods:` "
+                "entry — a directory with a `run.sh` that sparkrun copies into the container and runs before the "
+                "serve command — best when publishing an image is impractical or the change is small and "
+                "specific to this recipe, since it travels with the recipe through its registry and needs no "
+                "build infrastructure.",
             )
         )
     return found

--- a/src/sparkrun/core/validation.py
+++ b/src/sparkrun/core/validation.py
@@ -48,6 +48,7 @@ teaches people to ignore the ones they can.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Iterable, Mapping
 
@@ -345,6 +346,439 @@ def check_hardcoded_serve_flags(recipe: Recipe, runtime: RuntimePlugin | None) -
             break
 
     return found
+
+
+# --------------------------------------------------------------------------
+# Restated substitutions — values sparkrun would have supplied anyway
+# --------------------------------------------------------------------------
+
+#: Flags whose value *is* the model argument.  The positional forms
+#: (``vllm serve <id>``) are handled separately by :data:`_SERVE_VERBS`.
+_MODEL_ARG_FLAGS: tuple[str, ...] = (
+    "--model",
+    "--model-path",
+    "--model_path",
+    "--hf-model",
+    "--model-name-or-path",
+)
+
+#: Serve entry points that take the model as their first positional argument.
+#: Measured across the cached registries, this is where the restatement
+#: actually happens: every instance was ``vllm serve <literal id>``.
+_SERVE_VERBS: tuple[str, ...] = (
+    "vllm serve",
+    "sglang serve",
+    "sglang.launch_server",
+    "trtllm-serve",
+    "llama-server",
+    "spark serve",
+)
+
+#: Container-side paths sparkrun owns, and the reason each is wrong to write.
+#: ``/cache/huggingface`` is the mount point (``primitives.build_volumes``);
+#: ``HF_HOME``/``HF_HUB_CACHE`` point there (``RuntimePlugin.get_extra_env``),
+#: so the two ``$HOME``-relative spellings name a directory nothing populates.
+_MANAGED_CONTAINER_PATHS: Mapping[str, str] = {
+    "/cache/huggingface": "sparkrun's HuggingFace cache mount",
+    "/cache/runtime": "sparkrun's persistent runtime-cache mount",
+    "/root/.cache/huggingface": "the container's default HF cache, which sparkrun does not populate (it sets HF_HOME to its own mount)",
+    "~/.cache/huggingface": "the container's default HF cache, which sparkrun does not populate (it sets HF_HOME to its own mount)",
+}
+
+#: The ``models--<org>--<name>`` directory mangling inside an HF hub cache.
+#: An internal layout detail of ``huggingface_hub``, not an interface sparkrun
+#: promises; a path through it also pins the snapshot hash of one download.
+_HF_LAYOUT_RE = re.compile(r"models--[A-Za-z0-9_.-]+--[A-Za-z0-9_.-]+")
+
+
+def _model_arg_literal(command: str, model: str) -> str | None:
+    """Return the spelling by which *command* passes *model* as a literal.
+
+    Whole-token equality throughout, never a substring: measured across the
+    cached registries, the model id appears in a ``command:`` **only** as the
+    model argument — so exact matching costs nothing, while substring matching
+    would claim a ``--served-model-name`` or a chat-template path that merely
+    embeds the id.
+    """
+    tokens = [t for t in command.split() if t != "\\"]
+    for idx, token in enumerate(tokens):
+        for flag in _MODEL_ARG_FLAGS:
+            if token == flag and idx + 1 < len(tokens) and tokens[idx + 1] == model:
+                return flag
+            if token.startswith(flag + "=") and token[len(flag) + 1 :] == model:
+                return flag
+    for verb in _SERVE_VERBS:
+        # The verb's own tokens, then the first thing after them.
+        parts = verb.split()
+        for idx in range(len(tokens) - len(parts)):
+            if tokens[idx : idx + len(parts)] == parts and tokens[idx + len(parts)] == model:
+                return verb
+    return None
+
+
+def _script_texts(recipe: Recipe) -> list[tuple[str, str]]:
+    """``(where, text)`` for every shell snippet a recipe carries.
+
+    ``command:`` plus the three hook lists — the places a recipe supplies code
+    rather than configuration.  ``pre_exec`` entries may be a plain string or a
+    ``{host: cmd}`` mapping; both are flattened, since every consumer here is
+    asking about the text.
+
+    Read *before* ``mods.resolve_and_inject_mods`` runs (that happens inside
+    ``launch_inference``, well after validation), so these are the author's own
+    entries and never sparkrun's injected mod-runner.
+    """
+    out: list[tuple[str, str]] = []
+    if recipe.command:
+        out.append(("command", recipe.command))
+    for where in ("pre_exec", "post_exec", "post_commands"):
+        for entry in getattr(recipe, where, None) or ():
+            if isinstance(entry, Mapping):
+                out.extend((where, str(val)) for val in entry.values())
+            elif entry:
+                out.append((where, str(entry)))
+    return out
+
+
+def _defaults_texts(recipe: Recipe, *, skip_internal: bool) -> list[tuple[str, str]]:
+    """``(where, text)`` for each string ``defaults:`` value.
+
+    ``defaults`` is read as well as ``command:`` because a value reaches the
+    rendered command through its placeholder, so anything the command could
+    have said directly it can also say at one remove.  ``render_template``
+    iterates, so a default may even exist only to feed another.
+
+    *skip_internal* drops ``_``-prefixed keys.  The managed-path scan sets it,
+    because :func:`check_internal_config_keys` already reports that line as a
+    warning and says strictly more; the inline-script scan does not, because
+    "you declared a key sparkrun owns" and "you put a program in it" are two
+    different problems and the former's message covers neither the latter's
+    diagnosis nor its fix.
+
+    ``env:`` is read by neither.  It belongs to :func:`check_managed_cache_env`
+    and :func:`check_managed_comm_env`, whose whole subject is a recipe
+    touching sparkrun's wiring; a third message about the same assignment is
+    the noise this module's docstring warns against.
+    """
+    out: list[tuple[str, str]] = []
+    for key, val in (recipe.defaults or {}).items():
+        if not isinstance(key, str) or not isinstance(val, str):
+            continue
+        if skip_internal and key.startswith("_"):
+            continue
+        out.append(("defaults.%s" % key, val))
+    return out
+
+
+def _managed_path_texts(recipe: Recipe) -> list[tuple[str, str]]:
+    """``(where, text)`` for everything the managed-path scan reads.
+
+    :func:`_script_texts` plus ``defaults:`` values — a serve flag is just as
+    capable of naming a path sparkrun owns as the command is, and
+    ``defaults.chat_template`` pointing into the hub cache is the same mistake
+    at one remove.
+    """
+    return _script_texts(recipe) + _defaults_texts(recipe, skip_internal=True)
+
+
+def check_restated_substitutions(recipe: Recipe) -> list[RecipeIssue]:
+    """Report values sparkrun would have substituted, written out as literals.
+
+    The mirror image of :func:`check_hardcoded_serve_flags`: that one is about
+    values sparkrun *reads* from the config chain, this one about values it
+    *writes* into the command.  Both are suggestions and for the same reason —
+    the rendered command serves exactly what it says, identically everywhere —
+    but the mechanisms defeated are different, so the advice is different too.
+
+    ``recipe.model`` is rewritten mid-launch by three separate mechanisms, and
+    every one of them reaches the serve command only through ``{model}``:
+
+    * ``cluster_config.resolved_model_path`` repoints it at pre-placed on-disk
+      weights **and** sets ``_skip_model_distribution``
+      (``launcher.launch_inference``), so a literal asks the engine for a repo
+      id with the download deliberately skipped;
+    * an absolute path in ``model:`` is the same thing via user-facing sugar;
+    * a pre-synced GGUF replaces it with the resolved container path — which is
+      the entire point of ``SglangRuntime._inject_gguf_model``, since the raw
+      value still carries the sparkrun-specific ``:quant`` suffix that no
+      runtime can parse.
+
+    None of the three is under the recipe author's control; each is a fact
+    about the cluster it lands on.  Nothing *reads* the model back out of the
+    command, though, which is what keeps this a suggestion rather than a
+    warning: absent all three, the literal renders identically to ``{model}``.
+    """
+    found: list[RecipeIssue] = []
+    command = recipe.command or ""
+
+    # An absolute ``model:`` is already the on-disk path, so ``{model}`` would
+    # render the same string and none of the three mechanisms applies.  There
+    # is nothing to fix, and saying so anyway is how a report gets skimmed.
+    from sparkrun.core.recipe import is_local_model_path
+
+    if command and recipe.model and not is_local_model_path(recipe.model):
+        spelling = _model_arg_literal(command, recipe.model)
+        if spelling:
+            found.append(
+                RecipeIssue(
+                    SUGGESTION,
+                    "restated-model-arg",
+                    "command: passes the literal model id '%s' via '%s', which is exactly what `model:` already "
+                    "says. sparkrun rewrites the model argument at launch — for pre-placed on-disk weights "
+                    "(`resolved_model_path`, or an absolute `model:`) and for a pre-synced GGUF, where the "
+                    "resolved container path replaces the `repo:quant` spec the engine cannot parse — and it "
+                    "reaches the command only through the {model} placeholder. A literal is invisible to all of "
+                    "it." % (recipe.model, spelling),
+                    "Replace the literal with {model}. It renders identically today.",
+                )
+            )
+
+    for where, text in _managed_path_texts(recipe):
+        hits: list[str] = sorted({p for p in _MANAGED_CONTAINER_PATHS if p in text})
+        layout = sorted({m.group(0) for m in _HF_LAYOUT_RE.finditer(text)})
+        if not hits and not layout:
+            continue
+        detail = "; ".join("'%s' is %s" % (p, _MANAGED_CONTAINER_PATHS[p]) for p in hits)
+        if layout:
+            detail += ("; " if detail else "") + (
+                "'%s' is huggingface_hub's internal on-disk layout, not an interface sparkrun promises, and pins "
+                "the snapshot of one download" % layout[0]
+            )
+        found.append(
+            RecipeIssue(
+                SUGGESTION,
+                "restated-managed-path",
+                "%s: spells out a container path sparkrun manages (%s). Paths under sparkrun's mounts are "
+                "supplied by the launch — through {model}, HF_HOME/HF_HUB_CACHE and the runtime-cache env — so "
+                "restating one pins the recipe to a layout it does not control and skips the rewrites the "
+                "launch would have applied." % (where, detail),
+                "Reference the value sparkrun provides ({model}, or $HF_HOME / $HF_HUB_CACHE / $XDG_CACHE_HOME "
+                "inside the container) rather than the path it currently resolves to. If the path is genuinely "
+                "not reachable that way, keep it — this is advice, not a rule.",
+            )
+        )
+
+    return found
+
+
+# --------------------------------------------------------------------------
+# Inline scripting and patching
+# --------------------------------------------------------------------------
+
+#: Signals that a recipe is carrying a *program* rather than a command, keyed
+#: by the phrase used to name the evidence.  Every one of these is measured at
+#: **zero** across the 160 cached registry recipes, which is what lets the
+#: check be this broad: there is no idiom in the published corpus it collides
+#: with, and each names a specific tool rather than guessing from shape.
+#:
+#: Shape alone is deliberately *not* a signal.  A long ``command:`` is often
+#: just a serve invocation with many flags (the corpus clusters at 10-19 lines
+#: and no recipe exceeds 40), so a line-count threshold would report the
+#: recipes with the most flags rather than the ones carrying code.
+_INLINE_SCRIPT_SIGNALS: Mapping[str, Any] = {
+    "a heredoc delivering an inline program": re.compile(r"<<-?\s*['\"]?[A-Za-z_][A-Za-z0-9_]*['\"]?"),
+    "an inline interpreter program (`-c`)": re.compile(r"(?<![\w-])(python3?|perl|ruby|node)\s+-c(?![\w-])"),
+    "an interpreter reading its program from stdin": re.compile(r"(?<![\w-])(python3?|perl|ruby|node)\s+-\s"),
+    "in-place file editing (`sed -i`)": re.compile(r"(?<![\w-])sed\s+(?:-[a-zA-Z]+\s+)*-[a-zA-Z]*i(?![\w-])"),
+    "a source patch (`patch`/`git apply`)": re.compile(r"(?<![\w-])(patch\s+[^\n]*-p\d|git\s+apply(?![\w-]))"),
+    "a write into the installed package tree": re.compile(r"site-packages|dist-packages"),
+    "a package install at launch": re.compile(r"(?<![\w-])(uv\s+pip|pip3?|python3?\s+-m\s+pip)\s+install(?![\w-])"),
+    "a download at launch (`curl`/`wget`)": re.compile(r"(?<![\w-])(curl|wget)\s+[^\n]*https?://"),
+}
+
+#: Signals withheld from ``defaults:`` values, because there they are ambiguous
+#: in a way they are not in a command.  Every other signal names a *verb* —
+#: something being run — which is unambiguous wherever it appears; this one
+#: names a *location*, and in a command it is nearly always the target of a
+#: write while in a serve-flag value it is as likely to be a plain path
+#: (``chat_template: /usr/lib/python3.12/site-packages/vllm/.../tpl.jinja``).
+#: Reporting that as "an inline script" would be simply wrong.
+_SIGNALS_NOT_IN_DEFAULTS = frozenset({"a write into the installed package tree"})
+
+
+def check_inline_scripting(recipe: Recipe) -> list[RecipeIssue]:
+    """Suggest ``mods:`` when a recipe carries a program instead of a command.
+
+    A recipe that patches its own container — a heredoc'd Python program that
+    rewrites vLLM's source, a ``sed -i`` over the installed package, a
+    ``pip install`` before the serve line — is doing what ``mods:`` exists for,
+    and the difference is not stylistic.  A mod is a directory with a
+    ``run.sh``; sparkrun ``docker cp``s it into the container and runs it
+    before the serve command, so the script is a **file** that travels with the
+    recipe through its registry, can be reviewed and diffed on its own, and is
+    copied **verbatim**.
+
+    That last property is the sparkrun-specific argument, because the three
+    places a script can live are rendered differently and only one of them
+    leaves it alone:
+
+    * ``command:`` goes through ``Recipe.render_command``, whose brace-escape
+      mode is inferred *from the template itself*
+      (``utils.text.uses_brace_escapes``).  An embedded program with dict
+      literals, f-strings or shell brace expansion therefore has to double
+      every literal brace, and forces the whole template into the escape mode —
+      which is why the canonical instance of this shape is also a v1-format
+      recipe.  Get one brace wrong and the program is silently mis-rendered.
+    * a ``pre_exec`` string goes through ``hooks.render_hook_command``, which
+      does *not* collapse ``{{`` but does still substitute ``{name}`` — so a
+      program is safe from the escaping rule and still exposed to a collision
+      with any config-chain key it happens to spell.
+    * a mod's ``run.sh`` is never rendered at all.
+
+    A suggestion, not a warning: an inline patch runs identically on every
+    cluster, so nothing here breaks somewhere else — what is given up is
+    reviewability and the escaping hazard above.  It is also why the check is
+    free to be broad: it costs nothing at launch (``run`` does not print
+    suggestions) and the shapes are genuinely ambiguous enough that a
+    legitimate use is plausible.
+
+    Scanned in ``command:``, the hook lists, and ``defaults:`` values — a
+    default reaches the command through its placeholder, so a program can be
+    written there just as well, one remove further from where it runs.  That
+    last one is an edge case nobody has produced, which is why the *signal set*
+    narrows there rather than the scan being skipped: see
+    :data:`_SIGNALS_NOT_IN_DEFAULTS`.
+    """
+    found: list[RecipeIssue] = []
+    texts = [(w, t, _INLINE_SCRIPT_SIGNALS) for w, t in _script_texts(recipe)]
+    narrowed = {k: v for k, v in _INLINE_SCRIPT_SIGNALS.items() if k not in _SIGNALS_NOT_IN_DEFAULTS}
+    texts += [(w, t, narrowed) for w, t in _defaults_texts(recipe, skip_internal=False)]
+
+    for where, text, signals in texts:
+        evidence = sorted(name for name, pat in signals.items() if pat.search(text))
+        if not evidence:
+            continue
+        found.append(
+            RecipeIssue(
+                SUGGESTION,
+                "inline-script",
+                "%s: contains %s. A recipe that patches or installs into its own container is doing what `mods:` "
+                "exists for. Inline, the program is re-run on every node on every launch, cannot be reviewed or "
+                "diffed apart from the recipe, and — in `command:` — is passed through the placeholder renderer, "
+                "so every literal brace in it has to be escaped and one missed brace mis-renders the program "
+                "silently." % (where, ", ".join(evidence)),
+                "Move it to a `mods:` entry — a directory with a `run.sh`, copied into the container verbatim "
+                "and run before the serve command, which travels with the recipe through its registry and is "
+                "never passed through the renderer. For a package install, prefer baking it into the container "
+                "image so it is not repeated on every launch.",
+            )
+        )
+    return found
+
+
+# --------------------------------------------------------------------------
+# Sparkrun-owned config keys
+# --------------------------------------------------------------------------
+
+
+def check_internal_config_keys(recipe: Recipe) -> list[RecipeIssue]:
+    """Warn when ``defaults:`` declares a key sparkrun injects mid-launch.
+
+    A leading underscore marks the config-chain namespace sparkrun owns
+    (``_gguf_model_path``, ``_mmproj_path``).  Nothing reports these today:
+    ``launcher._is_internal_config_key`` excludes them from the unmapped-key
+    report — correctly, since they *are* consumed, so "unmapped" is the wrong
+    complaint — which leaves a recipe *declaring* one with no diagnostic at
+    all.
+
+    The injected value wins when it is produced (``overrides`` outranks
+    ``defaults`` in the config chain), so the recipe's literal is dead in the
+    ordinary case and reads as though it works.  It wins instead in exactly the
+    situations the author did not choose: under ``--dry-run`` (so the command
+    you review is not the command that runs), when the weights are pre-placed,
+    and when the GGUF was not pre-synced on this host — where it names a path
+    that need not exist.
+
+    A warning rather than an error because it is a real escape hatch: a
+    requirement that sparkrun's normal resolution cannot express is a reason to
+    keep the key, and being told is the point.  Scoped to *declaring* a key —
+    referencing ``{_gguf_model_path}`` in a template is reading, not writing,
+    and is left alone.
+    """
+    declared = sorted(k for k in (recipe.defaults or {}) if isinstance(k, str) and k.startswith("_"))
+    if not declared:
+        return []
+    return [
+        RecipeIssue(
+            WARNING,
+            "internal-config-key",
+            "defaults: declares %s. A leading underscore marks a value sparkrun injects into the config chain "
+            "mid-launch after resolving it against the cluster (the pre-synced GGUF's container path, the "
+            "multimodal projector's). The injected value outranks `defaults:`, so the recipe's is normally dead "
+            "— but the injection is skipped under --dry-run, for pre-placed weights, and when the model was not "
+            "pre-synced here, and then the recipe's literal wins and names a path that need not exist on this "
+            "host." % ", ".join("'%s'" % k for k in declared),
+            "Remove them and let sparkrun resolve the value; reference {model} (GGUF-resolved) or the public "
+            "`mmproj` key if the command needs it. Keep them only if the requirement is genuinely not reachable "
+            "through sparkrun's own resolution.",
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
+# Per-launch coordination flags
+# --------------------------------------------------------------------------
+
+
+def check_hardcoded_rendezvous_flags(recipe: Recipe, runtime: RuntimePlugin | None) -> list[RecipeIssue]:
+    """Warn when ``command:`` pins a flag the runtime computes per launch.
+
+    The flag list is the runtime's own
+    (:meth:`~sparkrun.runtimes.base.RuntimePlugin.managed_rendezvous_flags`),
+    never a shared core: which flags coordinate a launch is a property of the
+    engine.  Atlas spells the world ``--rank``/``--world-size`` where vLLM
+    spells it ``--node-rank``/``--nnodes``, llama.cpp dials workers with
+    ``--rpc``, and ``vllm-ray`` and ``trtllm`` rendezvous outside the serve
+    command entirely and so declare nothing.  A runtime that declares nothing
+    disables the check, which is also what an out-of-tree runtime built against
+    an older base class gets.
+
+    A warning, not a suggestion, because it breaks on a cluster that is not the
+    author's — and the *single-node* direction is the damaging one.  These
+    flags are appended unconditionally by ``generate_node_command``, with none
+    of the ``reconcile_flag_in_command`` guarding that ``--served-model-name``
+    and ``--distributed-executor-backend`` get.  So:
+
+    * multi-node — the flag appears twice; argparse takes the last, sparkrun's
+      value wins, and the recipe's is merely dead;
+    * single-node — sparkrun appends *nothing* (``SglangRuntime`` returns the
+      base command when ``world_nodes <= 1``; vLLM's block is under
+      ``replica_size > 1``), so the recipe's ``--nnodes 2 --node-rank 0`` and
+      the author's head IP survive verbatim.  The launch then rendezvouses with
+      a host that is not there, or trips sglang's ``(tp*pp) % nnodes == 0``
+      assertion before it binds a port (issue #284) — a failure that names
+      neither sparkrun nor the recipe.
+    """
+    command = recipe.command or ""
+    if not command or runtime is None:
+        return []
+
+    try:
+        managed = tuple(runtime.managed_rendezvous_flags() or ())
+    except Exception:  # pragma: no cover - defensive, mirrors known_config_keys
+        logger.debug("Runtime %r managed_rendezvous_flags raised", getattr(runtime, "runtime_name", "?"), exc_info=True)
+        return []
+    if not managed:
+        return []
+
+    tokens = {t for t in command.split() if t != "\\"}
+    found = sorted(f for f in managed if f in tokens or any(t.startswith(f + "=") for t in tokens))
+    if not found:
+        return []
+    return [
+        RecipeIssue(
+            WARNING,
+            "hardcoded-rendezvous-flag",
+            "command: hardcodes %s, which the '%s' runtime computes per launch from the cluster and the "
+            "placement and appends itself. On a multi-node launch the flag is emitted twice and the recipe's "
+            "value is silently dropped; on a single node sparkrun appends nothing at all, so the recipe's value "
+            "survives and the workload tries to coordinate with a topology — or a head address — that does not "
+            "exist there." % (", ".join("'%s'" % f for f in found), getattr(runtime, "runtime_name", recipe.runtime)),
+            "Remove them and let sparkrun size the world. Node count comes from `min_nodes`/`max_nodes` and the "
+            "parallelism keys (`tensor_parallel`, `pipeline_parallel`, `data_parallel`); the head address and "
+            "coordination port are resolved from the hosts the launch actually lands on.",
+        )
+    ]
 
 
 # --------------------------------------------------------------------------
@@ -1079,7 +1513,11 @@ def validate_recipe(
     issues.extend(_safe("managed-cache-env", lambda: check_managed_cache_env(recipe, runtime)))
     issues.extend(_safe("unknown-top-level-key", lambda: check_unknown_top_level_keys(recipe, runtime)))
     issues.extend(_safe("non-portable-mount", lambda: check_mount_portability(recipe)))
+    issues.extend(_safe("internal-config-key", lambda: check_internal_config_keys(recipe)))
+    issues.extend(_safe("inline-script", lambda: check_inline_scripting(recipe)))
+    issues.extend(_safe("hardcoded-rendezvous-flag", lambda: check_hardcoded_rendezvous_flags(recipe, runtime)))
     issues.extend(_safe("hardcoded-serve-flag", lambda: check_hardcoded_serve_flags(recipe, runtime)))
+    issues.extend(_safe("restated-substitution", lambda: check_restated_substitutions(recipe)))
 
     if runtime is not None and include_unmapped_keys:
         from sparkrun.core.launcher import report_unmapped_config_keys

--- a/src/sparkrun/core/validation.py
+++ b/src/sparkrun/core/validation.py
@@ -1241,6 +1241,35 @@ def check_deprecated_features(recipe: Recipe) -> list[RecipeIssue]:
                 )
             )
 
+        # Read off ``_raw``, and it has to be: ``Recipe.__init__`` assigns
+        # ``self.name`` from the source filename stem unconditionally — the
+        # ``data.get("name", ...)`` beside it is commented out — so the parsed
+        # attribute is *never* the declared value, and testing it would report
+        # every recipe or none.  The same trap as ``mode:``.  ``getattr``
+        # because ``__setstate__`` does not restore ``_raw``, so a recipe
+        # revived from the registry cache has no attribute at all.
+        #
+        # Gated on not-v1 for the reason the brace escape is: ``name:`` is the
+        # v1 spelling — every v1 recipe in the cached corpus declares one — and
+        # those already carry ``deprecated-recipe-format``, whose migration
+        # (convert to v2) subsumes this.  Three v2 recipes declare one, which
+        # is the population this is for.
+        raw_recipe = getattr(recipe, "_raw", None)
+        if isinstance(raw_recipe, Mapping) and "name" in raw_recipe:
+            declared = str(raw_recipe.get("name") or "")
+            found.append(
+                RecipeIssue(
+                    WARNING,
+                    "deprecated-recipe-name",
+                    "name: is the v1 spelling and is already ignored — sparkrun derives the recipe name from the "
+                    "filename on disk (or its path within a registry), so the declared value%s is discarded on "
+                    "load rather than being deprecated in the usual sense. A recipe that names itself one thing "
+                    "and resolves as another is only visible by listing it." % (" ('%s')" % declared if declared else ""),
+                    "Delete the key. The name is `%s`, taken from the file; rename the file to change it." % recipe.name,
+                    deprecation=True,
+                )
+            )
+
     migration = _DEPRECATED_RUNTIMES.get(recipe.runtime)
     if migration:
         found.append(

--- a/src/sparkrun/core/validation.py
+++ b/src/sparkrun/core/validation.py
@@ -799,6 +799,76 @@ def check_hardcoded_rendezvous_flags(recipe: Recipe, runtime: RuntimePlugin | No
 
 
 # --------------------------------------------------------------------------
+# Pinned model_revision never passed to the engine
+# --------------------------------------------------------------------------
+
+
+def check_unpinned_model_revision(recipe: Recipe, runtime: RuntimePlugin | None) -> list[RecipeIssue]:
+    """Warn when ``model_revision`` is pinned but the serve command drops it.
+
+    The pin reaches *distribution* — the weights downloaded are the right ones
+    — and then stops.  No flag map exposes a revision key, so unless the recipe
+    spells one of the runtime's ``model_revision_flags`` in ``command:``, the
+    engine is handed a bare repo id and resolves its own default revision.
+
+    That is fatal rather than merely unpinned, and the reason is the cache
+    layout.  HuggingFace writes ``refs/<branch>`` only when a repo is fetched
+    by branch *name*; a SHA-pinned download leaves ``snapshots/<sha>/`` and no
+    ``refs/`` directory at all.  The container runs with ``HF_HUB_OFFLINE=1``
+    (weights are pre-staged, so this is correct), so the engine cannot fall
+    back to the network: it looks for ``refs/main``, finds nothing, and raises
+    ``LocalEntryNotFoundError`` — after the whole model has already downloaded
+    and synced to every host.
+
+    A warning rather than an error because sparkrun *can* honor the recipe as
+    written, and because the failure is invisible on a machine whose cache
+    happens to carry a ``refs/`` entry from an earlier unpinned download of the
+    same repo — the classic works-here shape this severity exists for.
+
+    Skipped when the model is not a repo id the engine will resolve: an
+    absolute ``model:`` path or a ``cluster_config.resolved_model_path`` both
+    mean pre-placed weights served from a directory, where there is no
+    revision to look up.
+    """
+    if not getattr(recipe, "model_revision", None) or runtime is None:
+        return []
+
+    from sparkrun.core.recipe import is_local_model_path
+
+    if is_local_model_path(recipe.model):
+        return []
+    if getattr(getattr(recipe, "cluster_config", None), "resolved_model_path", None):
+        return []
+
+    try:
+        flags = tuple(runtime.model_revision_flags() or ())
+    except Exception:  # pragma: no cover - defensive, mirrors managed_rendezvous_flags
+        logger.debug("Runtime %r model_revision_flags raised", getattr(runtime, "runtime_name", "?"), exc_info=True)
+        return []
+    if not flags:
+        return []
+
+    command = recipe.command or ""
+    tokens = {t for t in command.split() if t != "\\"}
+    if any(f in tokens or any(t.startswith(f + "=") for t in tokens) for f in flags):
+        return []
+
+    primary = flags[0]
+    return [
+        RecipeIssue(
+            WARNING,
+            "unpinned-model-revision",
+            "model_revision is pinned to '%s', but command: never passes it to the engine — the '%s' runtime "
+            "takes the pin as %s and no defaults key maps to it. sparkrun downloads by commit SHA, which writes "
+            "no refs/ entry in the HuggingFace cache, and the container runs HF_HUB_OFFLINE=1 — so the engine "
+            "resolves its default revision, finds no ref, and dies with LocalEntryNotFoundError after the model "
+            "has already downloaded." % (recipe.model_revision, getattr(runtime, "runtime_name", recipe.runtime), primary),
+            "Add `%s {model_revision}` to the command: template, or drop the model_revision pin." % primary,
+        )
+    ]
+
+
+# --------------------------------------------------------------------------
 # Sparkrun-managed communication env
 # --------------------------------------------------------------------------
 
@@ -1562,6 +1632,7 @@ def validate_recipe(
     issues.extend(_safe("internal-config-key", lambda: check_internal_config_keys(recipe)))
     issues.extend(_safe("inline-script", lambda: check_inline_scripting(recipe)))
     issues.extend(_safe("hardcoded-rendezvous-flag", lambda: check_hardcoded_rendezvous_flags(recipe, runtime)))
+    issues.extend(_safe("unpinned-model-revision", lambda: check_unpinned_model_revision(recipe, runtime)))
     issues.extend(_safe("hardcoded-serve-flag", lambda: check_hardcoded_serve_flags(recipe, runtime)))
     issues.extend(_safe("restated-substitution", lambda: check_restated_substitutions(recipe)))
 

--- a/src/sparkrun/diagnostics/__init__.py
+++ b/src/sparkrun/diagnostics/__init__.py
@@ -3,6 +3,8 @@
 Public API:
     - :func:`collect_spark_diagnostics` — collect hardware/firmware/network/Docker
       info from one or more hosts.
+    - :func:`summarize_host_diagnostics` — condense one host's raw probe output
+      into a display summary (platform, OS, CPU/RAM, GPU + driver, CUDA, Docker).
     - :class:`NDJSONWriter` — append-only, immediate-flush NDJSON writer.
     - :class:`RunDiagnosticsCollector` — wraps a ``sparkrun run`` lifecycle with
       phase timing, error capture, and log collection.
@@ -15,6 +17,7 @@ from sparkrun.diagnostics.spark_collector import (
     collect_config_diagnostics,
     collect_spark_diagnostics,
     collect_sudo_diagnostics,
+    summarize_host_diagnostics,
 )
 from sparkrun.diagnostics.run_collector import RunDiagnosticsCollector
 
@@ -24,4 +27,5 @@ __all__ = [
     "collect_config_diagnostics",
     "collect_spark_diagnostics",
     "collect_sudo_diagnostics",
+    "summarize_host_diagnostics",
 ]

--- a/src/sparkrun/diagnostics/spark_collector.py
+++ b/src/sparkrun/diagnostics/spark_collector.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import time
+from typing import Any, Mapping
 
 from sparkrun.diagnostics.ndjson_writer import NDJSONWriter
 from sparkrun.orchestration.ssh import run_remote_scripts_parallel
@@ -152,6 +153,86 @@ def _extract_firmware_history(kv: dict[str, str]) -> list[dict[str, str]]:
             }
         )
     return history
+
+
+def _diag_str(kv: Mapping[str, str], key: str) -> str:
+    """Return a trimmed value, or ``""`` when absent/blank."""
+    return str(kv.get(key, "")).strip()
+
+
+def _diag_int(kv: Mapping[str, str], key: str) -> int | None:
+    """Return an int value, or ``None`` when absent/blank/non-numeric."""
+    raw = _diag_str(kv, key)
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return None
+
+
+def summarize_host_diagnostics(kv: Mapping[str, str]) -> dict[str, Any]:
+    """Condense raw ``spark_diagnose.sh`` output into a display summary.
+
+    The collector's own consumers (:func:`collect_spark_diagnostics`'s NDJSON
+    records) keep every probed key; this is the *reporting* peer for callers
+    that show a person a handful of identity/version lines — platform, OS,
+    CPU/RAM, GPU + driver, CUDA, Docker.
+
+    Empty values are **omitted** rather than rendered blank: the probe emits a
+    key for everything it looks for, so ``DIAG_CUDA_VERSION=`` means "no nvcc
+    on this host", which is not the same as "CUDA 0" and should not occupy a
+    line.  Sizes are converted to GB here so every renderer reports them the
+    same way.
+
+    Note the GPU fields describe the **first** GPU only — that is what
+    ``spark_diagnose.sh`` reports, and it is sufficient on a one-GPU-per-host
+    DGX Spark.  Serial and UUID are deliberately excluded: they identify a
+    specific unit and this summary is meant to be pasteable into a bug report.
+
+    Args:
+        kv: Parsed key=value output for one host (a value of the mapping
+            returned by :func:`collect_spark_diagnostics`).
+
+    Returns:
+        Ordered mapping of summary field → value, empty when *kv* carries
+        nothing recognisable (e.g. the probe failed on that host).
+    """
+    out: dict[str, Any] = {}
+
+    def put(key: str, value: Any) -> None:
+        if value not in ("", None):
+            out[key] = value
+
+    put("hostname", _diag_str(kv, "DIAG_HOSTNAME"))
+    put("product", _diag_str(kv, "DIAG_PRODUCT_NAME"))
+    put("board", _diag_str(kv, "DIAG_BOARD_NAME"))
+    put("bios_version", _diag_str(kv, "DIAG_BIOS_VERSION"))
+
+    put("os", _diag_str(kv, "DIAG_OS_PRETTY") or _diag_str(kv, "DIAG_OS_NAME"))
+    put("kernel", _diag_str(kv, "DIAG_KERNEL"))
+    put("arch", _diag_str(kv, "DIAG_ARCH"))
+
+    put("cpu_model", _diag_str(kv, "DIAG_CPU_MODEL"))
+    put("cpu_cores", _diag_int(kv, "DIAG_CPU_CORES"))
+    put("cpu_threads", _diag_int(kv, "DIAG_CPU_THREADS"))
+    ram_kb = _diag_int(kv, "DIAG_RAM_TOTAL_KB")
+    if ram_kb:
+        put("ram_total_gb", round(ram_kb / 1024 / 1024, 1))
+
+    put("gpu_name", _diag_str(kv, "DIAG_GPU_NAME"))
+    gpu_mb = _diag_int(kv, "DIAG_GPU_MEMORY_MB")
+    if gpu_mb:
+        put("gpu_memory_gb", round(gpu_mb / 1024, 1))
+    put("gpu_driver", _diag_str(kv, "DIAG_GPU_DRIVER"))
+    put("cuda_version", _diag_str(kv, "DIAG_CUDA_VERSION"))
+    put("jetpack_version", _diag_str(kv, "DIAG_JETPACK_VERSION"))
+
+    put("docker_version", _diag_str(kv, "DIAG_DOCKER_VERSION"))
+    put("docker_storage_driver", _diag_str(kv, "DIAG_DOCKER_STORAGE"))
+    docker_nvidia = _diag_str(kv, "DIAG_DOCKER_NVIDIA_RUNTIME")
+    if docker_nvidia:
+        out["docker_nvidia_runtime"] = docker_nvidia == "true"
+
+    return out
 
 
 def collect_sudo_diagnostics(

--- a/src/sparkrun/models/dtypes.py
+++ b/src/sparkrun/models/dtypes.py
@@ -93,6 +93,41 @@ _DTYPE_CANONICAL: dict[str, str] = {
     "bf16": "bfloat16",
 }
 
+# Weight formats whose width is a per-checkpoint bits-per-weight figure rather
+# than a fixed packing, so no table entry can cover them: exllamav3 publishes
+# 2.05 / 3.05 / 4.05 bpw builds of the same model as separate branches of one
+# repo.  The width therefore travels *in* the dtype string — ``exl3:2.05`` — and
+# is read back by :func:`bytes_per_element`.
+#
+# Scoped to a declared set so an arbitrary ``foo:1.5`` stays unknown, and
+# weight-only by design: these are never KV-cache layouts, which is why the
+# parse is absent from :func:`kv_bytes_per_element`.
+#
+# The figure is nominal, matching every other entry here.  Real checkpoints run
+# a few percent above it (a separately-quantized ``head_bits`` plus trellis
+# scale overhead), which is within what a VRAM *estimate* is for.
+_BPW_FAMILIES = frozenset({"exl2", "exl3"})
+
+# Below 1 nothing ships; above 16 the caller means a float dtype and is reading
+# the wrong table.  Bounds exist so a typo'd ``exl3:205`` is rejected rather
+# than silently sizing the model 100x too large.
+_BPW_MIN = 1.0
+_BPW_MAX = 16.0
+
+
+def _bits_per_weight_bytes(key: str) -> float | None:
+    """Bytes per weight for a ``<family>:<bits>`` dtype key, or None."""
+    family, sep, bits = key.partition(":")
+    if not sep or family not in _BPW_FAMILIES:
+        return None
+    try:
+        parsed = float(bits)
+    except ValueError:
+        return None
+    if not (_BPW_MIN <= parsed <= _BPW_MAX):
+        return None
+    return parsed / 8.0
+
 
 def dtype_key(dtype: str) -> str:
     """Fold a dtype spelling to its lookup key.
@@ -117,8 +152,15 @@ def normalize_dtype(dtype: str) -> str:
 
 
 def bytes_per_element(dtype: str) -> float | None:
-    """Return bytes per element for a dtype string, or None if unknown."""
-    return _DTYPE_BYTES.get(dtype_key(dtype))
+    """Return bytes per element for a dtype string, or None if unknown.
+
+    Covers the fixed table plus the bits-parameterized ``<family>:<bits>``
+    spelling (``exl3:2.05``) — see :data:`_BPW_FAMILIES`.  A bare family name
+    stays unknown, because it is not sizable: the bpw *is* the width.
+    """
+    key = dtype_key(dtype)
+    known = _DTYPE_BYTES.get(key)
+    return known if known is not None else _bits_per_weight_bytes(key)
 
 
 def kv_bytes_per_element(dtype: str) -> float | None:

--- a/src/sparkrun/models/quantization.py
+++ b/src/sparkrun/models/quantization.py
@@ -19,8 +19,8 @@ logger = logging.getLogger(__name__)
 class QuantizationInfo:
     """Detected quantization metadata for a model."""
 
-    method: str  # "awq", "gptq", "fp8", "nvfp4", "mxfp4", "bitsandbytes", "compressed-tensors", "none"
-    bits: int | None  # 4, 8, None (for fp8/mxfp4 where bits is implicit)
+    method: str  # "awq", "gptq", "fp8", "nvfp4", "mxfp4", "bitsandbytes", "compressed-tensors", "exl3", "none"
+    bits: float | None  # 4, 8, None (implicit for fp8/mxfp4); fractional for exl2/exl3
     weight_dtype: str  # Effective dtype for VRAM: "awq4", "gptq", "fp8", "nvfp4", "mxfp4", "int4", "int8"
     kv_cache_quant: str | None = None  # From hf_quant_config.json (e.g. "fp8")
     group_size: int | None = None  # Quantization group size
@@ -221,6 +221,20 @@ def _resolve_from_quantization_config(qc: dict[str, Any]) -> QuantizationInfo | 
         if qc.get("load_in_8bit"):
             return QuantizationInfo(method="bitsandbytes", bits=8, weight_dtype="int8")
         return None
+
+    if method in ("exl2", "exl3"):
+        # Fractional, per-checkpoint bits-per-weight (2.05, 3.05, 4.05 ship as
+        # separate branches of one repo), so the width cannot be a table entry
+        # and travels in the dtype string instead — see dtypes._BPW_FAMILIES.
+        # Reading it here is what lets a recipe omit ``metadata.model_dtype``
+        # entirely: estimate_vram writes the detected value back.
+        if bits is None:
+            return None
+        try:
+            bpw = float(bits)
+        except (TypeError, ValueError):
+            return None
+        return QuantizationInfo(method=method, bits=bpw, weight_dtype="%s:%g" % (method, bpw))
 
     if method == "mxfp4":
         return QuantizationInfo(method="mxfp4", bits=4, weight_dtype="mxfp4")

--- a/src/sparkrun/orchestration/distribution.py
+++ b/src/sparkrun/orchestration/distribution.py
@@ -35,6 +35,20 @@ class DistributionError(TransferError):
     """Raised when resource distribution (image or model sync) fails."""
 
 
+def _force_registry_pull_for_recipe(recipe: "Recipe") -> bool:
+    """Return whether ``rebuild`` means re-pull the resolved registry image.
+
+    Recipes without a builder, and recipes using the explicit ``docker-pull``
+    builder, delegate freshness to distribution.  Builders such as ColdSnap
+    and EUGR produce a new local image themselves; forcing a registry pull of
+    that derived name would discard the successful build and usually fail
+    because the image has not been published.
+    """
+    rebuild = bool(recipe.builder_config.get("rebuild")) if recipe.builder_config else False
+    builder = str(getattr(recipe, "builder", "") or "").strip()
+    return rebuild and builder in {"", "docker-pull"}
+
+
 @dataclass
 class TransferModeResult:
     """Result of :func:`resolve_auto_transfer_mode`.
@@ -804,7 +818,7 @@ def distribute_from_config(
     # which declares no builder at all and so never reaches the builder phase —
     # the equivalent is an unconditional `docker pull`.  Reading it here rather
     # than in the builder is what makes the flag reach those recipes.
-    _force_pull = bool(recipe.builder_config.get("rebuild")) if recipe.builder_config else False
+    _force_pull = _force_registry_pull_for_recipe(recipe)
     if _force_pull:
         logger.info("rebuild requested; forcing a fresh pull of image '%s'", image)
 

--- a/src/sparkrun/orchestration/executors/_base.py
+++ b/src/sparkrun/orchestration/executors/_base.py
@@ -90,7 +90,13 @@ class ExecutorConfig:
     restart_policy: str | None = None
     privileged: bool = True
     gpus: str = "all"
-    ipc: str = "host"
+    # ``shareable`` rather than ``host``: a host IPC namespace puts the
+    # workload's POSIX semaphores in the host's /dev/shm owned by the
+    # container user, where systemd-logind's RemoveIPC reaps them once the
+    # launching SSH session closes.  See ``docker.DOCKER_IPC_DEFAULT`` for the
+    # full rationale — the Docker layer overrides this with the same value;
+    # this is the bottom-of-chain fallback for a config built without it.
+    ipc: str = "shareable"
     shm_size: str = "25gb"
     network: str = "host"
     user: str | None = None
@@ -379,7 +385,7 @@ class Executor(Plugin):
         """Per-executor default settings — lowest-priority chain layer.
 
         Override to ship sensible defaults (e.g. DockerExecutor's
-        ``shm_size``/``ipc=host``).  Bare base class contributes
+        ``shm_size``/``ipc=shareable``).  Bare base class contributes
         nothing — the dataclass field defaults already provide the
         bottom layer.
         """

--- a/src/sparkrun/orchestration/executors/docker.py
+++ b/src/sparkrun/orchestration/executors/docker.py
@@ -2,7 +2,7 @@
 
 ``DockerExecutor`` generates Docker CLI command strings from
 ``ExecutorConfig`` settings.  The Docker-flavoured global defaults
-(``privileged``, ``ipc=host``, ``shm_size``, ...) and the
+(``privileged``, ``ipc=shareable``, ``shm_size``, ...) and the
 ``rootless``/``auto_user`` adjustment layer live here — they are not
 shared concerns of other executors.
 """
@@ -13,6 +13,7 @@ import json
 import logging
 import re
 import time
+from functools import lru_cache
 from typing import Mapping, TYPE_CHECKING
 
 from sparkrun.orchestration.executors._base import (
@@ -50,6 +51,39 @@ GPU_ACCESS_MODES = frozenset({GPU_ACCESS_CDI, GPU_ACCESS_GPUS})
 #: choice and the only one some daemons accept (see :func:`_nvidia_gpu_args`);
 #: hardware that prefers ``--gpus`` says so at the platform tier.
 GPU_ACCESS_DEFAULT = GPU_ACCESS_CDI
+
+#: The ``--ipc`` value that puts the workload on the *host's* IPC namespace
+#: and ``/dev/shm``.  Named because several call sites test for it.
+DOCKER_IPC_HOST = "host"
+
+#: ``ipc`` — the default IPC namespace mode.  ``shareable`` gives the container
+#: its *own* IPC namespace and its own ``/dev/shm`` (so :data:`DOCKER_DEFAULTS`'s
+#: ``shm_size`` applies) while still allowing a second container on the same host
+#: to join it with ``--ipc=container:<name>`` — the DP/PD service-domain shape.
+#: ``private`` would buy the same isolation and forbid that, at no saving.
+#:
+#: It is deliberately not :data:`DOCKER_IPC_HOST`.  Under ``--ipc=host`` the
+#: container's ``/dev/shm`` *is* the host's, so every POSIX semaphore and
+#: shared-memory segment the workload creates is a host file owned by the
+#: container user — which for sparkrun is the SSH user (``--user
+#: $(id -u):$(id -g)``, see :meth:`DockerExecutor.apply_runtime_adjustments`).
+#: systemd-logind with ``RemoveIPC=yes`` (the Ubuntu 24.04 / DGX OS default)
+#: deletes exactly those objects ``UserStopDelaySec`` after that user's last
+#: session ends — and sparkrun launches detached (``docker exec -d``) and then
+#: *closes* the SSH session.  A workload reaching Python's multiprocessing
+#: bootstrap after the reaper runs dies on ``SemLock._rebuild`` →
+#: ``FileNotFoundError``; one that gets there first survives indefinitely,
+#: because unlinking a name does not invalidate an already-open handle.  Hence
+#: the reported symptom: intermittent, and cured by holding an unrelated SSH
+#: session open.  See issue #285.
+#:
+#: A container-owned namespace is invisible to that reaper (logind walks
+#: ``/dev/shm`` itself, not arbitrary mounts), which is why this is a fix and
+#: not a mitigation.  ``host`` remains available as an explicit override for
+#: the case that needs it — cross-*container* NCCL/shm on a single host — with
+#: :func:`_warn_host_ipc_reaper` flagging the hazard when it is combined with a
+#: non-root container user.
+DOCKER_IPC_DEFAULT = "shareable"
 
 
 def _nvidia_gpu_args(gpus: str | None, mode: str | None = None) -> list[str]:
@@ -102,6 +136,45 @@ def _nvidia_gpu_args(gpus: str | None, mode: str | None = None) -> list[str]:
 # ``docker run`` doesn't fail with "no such file or directory" when the node
 # isn't present; hosts that have it (IB-equipped DGX Spark clusters) still get it.
 _OPTIONAL_DEVICES = frozenset({"/dev/infiniband"})
+
+
+def _is_root_container_user(user: str | None) -> bool:
+    """Would *user* run the container as UID 0?
+
+    ``None`` (no ``--user``) means the image's own user, which is root for
+    every inference image sparkrun ships against — so it counts as root here.
+    The ``$SHELL_USER`` sentinel resolves on the host to ``$(id -u):$(id -g)``
+    and is unknowable at generation time; it is treated as **non**-root, which
+    is the fail-loud direction for an advisory (a cluster whose SSH user really
+    is root gets one spurious line; the reverse would silence the real case).
+    """
+    if user is None:
+        return True
+    spelled = user.strip().split(":", 1)[0].strip()
+    return spelled in ("0", "root")
+
+
+@lru_cache(maxsize=None)
+def _warn_host_ipc_reaper(user: str) -> None:
+    """Warn that ``--ipc=host`` + a non-root container user is reapable.
+
+    Cached for its side effect: the condition is a property of the resolved
+    config, not of a node, so an N-node launch would otherwise emit N identical
+    lines.  Keyed by *user* so a cluster mixing users still reports each.
+
+    See :data:`DOCKER_IPC_DEFAULT` for the mechanism.
+    """
+    logger.warning(
+        "Docker executor: ipc=host with a non-root container user (%s) puts this workload's "
+        "POSIX semaphores and shared memory in the host's /dev/shm, where systemd-logind "
+        "(RemoveIPC=yes) deletes them shortly after the launching SSH session closes. A "
+        "detached launch can then fail during startup with FileNotFoundError in "
+        "multiprocessing's SemLock._rebuild. Drop the ipc override to use sparkrun's default "
+        "(%r), or run 'sudo loginctl enable-linger %s' on each host. See issue #285.",
+        user,
+        DOCKER_IPC_DEFAULT,
+        user if user != "$SHELL_USER" else "<ssh-user>",
+    )
 
 
 def _optional_device_arg(dev: str) -> str:
@@ -172,14 +245,23 @@ def _mask_sensitive_env_in_command(command: str, env: dict[str, str] | None) -> 
 # the :class:`ExecutorConfig` dataclass field defaults and below
 # everything else.  Lives with :class:`DockerExecutor` because every
 # value here is Docker-specific (``--privileged``, ``--shm-size``,
-# ``--ipc=host`` etc.).
+# ``--ipc=shareable`` etc.).
+#
+# NOTE ``ipc`` and ``shm_size`` are coupled and must move together: Docker
+# ignores ``--shm-size`` whenever ``--ipc=host`` (the container just gets the
+# host's ``/dev/shm``, typically 50% of RAM).  This value was therefore inert
+# until the ``ipc`` default changed, and is load-bearing now — 32 GB is well
+# above what a Spark can actually commit to tmpfs once ~85% of its 128 GB
+# unified memory is held by model weights and KV cache, and 500x Docker's
+# 64 MB default.  Raise it per-recipe (``executor_config: {shm_size: 64gb}``)
+# on a large-RAM non-Spark host if a workload needs more.
 DOCKER_DEFAULTS = {
     "auto_remove": True,
     "restart_policy": None,
     "privileged": True,
     "gpus": "all",
     "gpu_access_mode": GPU_ACCESS_DEFAULT,
-    "ipc": "host",
+    "ipc": DOCKER_IPC_DEFAULT,
     "shm_size": "32gb",
     "network": "host",
     "user": None,
@@ -206,7 +288,7 @@ class DockerExecutor(Executor):
 
     @classmethod
     def default_config(cls) -> dict:
-        """Docker-flavoured defaults — shm_size, ipc=host, network=host, ...."""
+        """Docker-flavoured defaults — shm_size, ipc=shareable, network=host, ...."""
         return dict(DOCKER_DEFAULTS)
 
     @classmethod
@@ -297,6 +379,8 @@ class DockerExecutor(Executor):
             opts.append("--privileged")
         opts.extend(self._accelerator_opts())
         if cfg.ipc:
+            if cfg.ipc.strip().lower() == DOCKER_IPC_HOST and not _is_root_container_user(cfg.user):
+                _warn_host_ipc_reaper(cfg.user)
             opts.append("--ipc=%s" % quote(cfg.ipc))
         if cfg.shm_size:
             opts.append("--shm-size=%s" % quote(cfg.shm_size))

--- a/src/sparkrun/orchestration/job_metadata.py
+++ b/src/sparkrun/orchestration/job_metadata.py
@@ -347,6 +347,16 @@ def derive_recipe_fingerprint(recipe: "Recipe", overrides: dict | None = None) -
 
     config_chain = recipe.build_config_chain(overrides)
     for key in sorted(config_chain.keys()):
+        # ``Recipe.build_config_chain`` injects the top-level model revision as
+        # a command-template variable.  The fingerprint already records
+        # ``recipe.model_revision`` below, and the injected helper was added
+        # after published ColdSnap artifact tags began using this digest.
+        # Elide only that implicit duplicate so adding template support does
+        # not invalidate existing artifact references.  A revision explicitly
+        # declared in defaults or supplied as an override remains part of the
+        # config-chain surface because it can change the rendered command.
+        if key == "model_revision" and key not in recipe.defaults and key not in (overrides or {}):
+            continue
         parts.append("%s=%s" % (key, _val(config_chain.get(key))))
 
     for attr in (

--- a/src/sparkrun/orchestration/sudo.py
+++ b/src/sparkrun/orchestration/sudo.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import subprocess
+from typing import Any
 
 from sparkrun.orchestration import ssh as _ssh
 from sparkrun.orchestration.ssh import RemoteResult
@@ -413,6 +414,7 @@ def ensure_remote_dir_ownership(
     ssh_options: list[str] | None = None,
     dry_run: bool = False,
     resource_label: str = "cache",
+    session: Any | None = None,
 ) -> list[str]:
     """Best-effort ``chown`` of *dir_path* to the SSH user on each host.
 
@@ -435,17 +437,30 @@ def ensure_remote_dir_ownership(
     # and tilde expansion does not happen inside the double quotes this script
     # interpolates into, so it has to become "$HOME/...".
     script = _FIX_OWNERSHIP_SCRIPT.format(path=safe_remote_path(dir_path))
-    results = _ssh.run_remote_scripts_parallel(
-        hosts,
-        script,
-        ssh_user=ssh_user,
-        ssh_key=ssh_key,
-        ssh_options=ssh_options,
-        timeout=60,
-        dry_run=dry_run,
-    )
-
-    failed = [r.host for r in results if not r.success]
+    if session is None:
+        results = _ssh.run_remote_scripts_parallel(
+            hosts,
+            script,
+            ssh_user=ssh_user,
+            ssh_key=ssh_key,
+            ssh_options=ssh_options,
+            timeout=60,
+            dry_run=dry_run,
+        )
+        failed = [result.host for result in results if not result.success]
+    elif dry_run:
+        failed = []
+    else:
+        failed = []
+        for host in hosts:
+            try:
+                result = session.execute(host, ["bash", "-c", script], timeout=60)
+            except Exception:
+                logger.debug("Could not repair %s ownership on %s", resource_label, host, exc_info=True)
+                failed.append(host)
+            else:
+                if result.returncode != 0:
+                    failed.append(host)
     if failed:
         logger.warning(
             "Could not fix %s ownership on %d host(s) (%s) — a root-owned "

--- a/src/sparkrun/plugins/__init__.py
+++ b/src/sparkrun/plugins/__init__.py
@@ -21,10 +21,14 @@ from sparkrun.core.recipe_items import (
     RecipeItemHandler,
     register_recipe_item,
 )
+from sparkrun.core.registry import RegistryEntry
+from sparkrun.core.registry_defaults import register_default_registry
 
 __all__ = [
     "FunctionalRecipeItemHandler",
     "RecipeItemHandler",
+    "RegistryEntry",
     "register_cli_command",
+    "register_default_registry",
     "register_recipe_item",
 ]

--- a/src/sparkrun/runtimes/_vllm_common.py
+++ b/src/sparkrun/runtimes/_vllm_common.py
@@ -20,6 +20,19 @@ class VllmMixin:
     def get_common_env(self):
         return default_env_hf_offline()
 
+    def model_revision_flags(self) -> tuple[str, ...]:
+        """vLLM spells the model repo pin ``--revision``.
+
+        Declared on the mixin rather than per runtime because every vLLM
+        variant shares the argument parser — unlike ``managed_rendezvous_flags``,
+        where ``vllm-ray`` rendezvouses through Ray and so declares nothing.
+
+        Note ``get_common_env`` is what makes this load-bearing: it sets
+        ``HF_HUB_OFFLINE``, so an unpassed pin cannot be papered over by the
+        engine reaching the Hub at startup.
+        """
+        return ("--revision",)
+
     def known_config_keys(self) -> frozenset[str]:
         """Flag-map keys plus the vLLM keys read outside it.
 

--- a/src/sparkrun/runtimes/atlas.py
+++ b/src/sparkrun/runtimes/atlas.py
@@ -286,6 +286,15 @@ class AtlasRuntime(RuntimePlugin):
         """Atlas handles its own multi-rank distribution via NCCL, not Ray."""
         return "native"
 
+    def managed_rendezvous_flags(self) -> tuple[str, ...]:
+        """Atlas spells the world ``--rank``/``--world-size``, not vLLM's ``--node-rank``/``--nnodes``.
+
+        The overlap with vLLM-distributed is only ``--master-addr`` /
+        ``--master-port``; the other two are a different vocabulary for the same
+        idea, which is why this list is declared rather than shared.
+        """
+        return ("--rank", "--world-size", "--master-addr", "--master-port")
+
     def resolve_api_key(
         self,
         recipe: "Recipe",

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -540,6 +540,32 @@ class RuntimePlugin(Plugin):
         """
         return ()
 
+    def model_revision_flags(self) -> tuple[str, ...]:
+        """Serve flags that pin the model repo revision for this engine.
+
+        Declared for :func:`sparkrun.core.validation.check_unpinned_model_revision`.
+        Unlike :meth:`managed_rendezvous_flags`, sparkrun does **not** append
+        these — no flag map exposes them — so a recipe that pins
+        ``model_revision`` must spell one itself in ``command:`` or the engine
+        never learns the pin.
+
+        That matters because sparkrun downloads by raw commit SHA.  HuggingFace
+        writes ``refs/<branch>`` only when a repo is fetched by branch *name*,
+        so a SHA-pinned download leaves ``snapshots/<sha>/`` and no ``refs/`` at
+        all; the container then runs ``HF_HUB_OFFLINE=1``, the engine resolves
+        its default revision (``main``), finds no ref, and dies with
+        ``LocalEntryNotFoundError`` after the weights have already synced.
+
+        Per-runtime with no shared core, for the same reason as
+        :meth:`managed_rendezvous_flags`: how an engine spells this is a
+        property of the engine.  The base default ``()`` disables the check,
+        which is the right answer for runtimes that never hand a repo id to an
+        engine that resolves it (``llama-cpp`` serves a local GGUF file) and the
+        safe answer for an out-of-tree runtime built against an older base
+        class.
+        """
+        return ()
+
     def generate_node_command(
         self,
         recipe: Recipe,

--- a/src/sparkrun/runtimes/base.py
+++ b/src/sparkrun/runtimes/base.py
@@ -514,6 +514,32 @@ class RuntimePlugin(Plugin):
         """
         return init_port
 
+    def managed_rendezvous_flags(self) -> tuple[str, ...]:
+        """Serve flags this runtime computes per launch and appends itself.
+
+        Declared for :func:`sparkrun.core.validation.check_hardcoded_rendezvous_flags`,
+        which warns when a recipe ``command:`` pins one.  Unlike the flags in
+        ``serve_flag_map``, these are **appended unconditionally** by
+        :meth:`generate_node_command` — no ``reconcile_flag_in_command``, no
+        "only if absent" guard — because their values are properties of the
+        cluster and the placement, not of the recipe.
+
+        The list is deliberately per-runtime with no shared core, even where
+        two runtimes spell a flag identically: which flags coordinate a launch
+        is a property of the engine, and a new runtime is far more likely to
+        need its own set than to inherit a neighbour's.  A family-neutral
+        default would quietly apply vLLM's vocabulary to an engine that never
+        had it.
+
+        The base default is ``()`` — "declares nothing", which disables the
+        check.  That is the right answer for the runtimes whose rendezvous
+        happens outside the serve command entirely (``vllm-ray`` delegates to
+        Ray, ``trtllm`` to ``mpirun -H``) and the safe answer for an
+        out-of-tree runtime built against an older base class, which is why
+        the check is opt-in rather than opt-out.
+        """
+        return ()
+
     def generate_node_command(
         self,
         recipe: Recipe,

--- a/src/sparkrun/runtimes/llama_cpp.py
+++ b/src/sparkrun/runtimes/llama_cpp.py
@@ -119,6 +119,15 @@ class LlamaCppRuntime(RuntimePlugin):
         """llama.cpp uses native RPC-based distribution, not Ray."""
         return "native"
 
+    def managed_rendezvous_flags(self) -> tuple[str, ...]:
+        """``--rpc`` carries the worker address list, built from the placement.
+
+        The whole set is one flag, and it shares no spelling with any other
+        runtime — llama.cpp's workers are ``rpc-server`` processes the head
+        dials out to, not ranks in a process group.
+        """
+        return ("--rpc",)
+
     def resolve_api_key(
         self,
         recipe: "Recipe",

--- a/src/sparkrun/runtimes/sglang.py
+++ b/src/sparkrun/runtimes/sglang.py
@@ -244,6 +244,14 @@ class SglangRuntime(RuntimePlugin):
         """
         return ("--dist-init-addr", "--nnodes", "--node-rank")
 
+    def model_revision_flags(self) -> tuple[str, ...]:
+        """SGLang spells the model repo pin ``--revision``, as vLLM does.
+
+        Same spelling, separate declaration: the overlap is a coincidence of
+        two engines borrowing HuggingFace's vocabulary, not a shared base.
+        """
+        return ("--revision",)
+
     def native_rendezvous_port(
         self,
         recipe: "Recipe | None",

--- a/src/sparkrun/runtimes/sglang.py
+++ b/src/sparkrun/runtimes/sglang.py
@@ -234,6 +234,16 @@ class SglangRuntime(RuntimePlugin):
             return max(1, parallelism.model_shard_factor)
         return super().world_size(parallelism, recipe=recipe, cluster=cluster)
 
+    def managed_rendezvous_flags(self) -> tuple[str, ...]:
+        """The three flags :meth:`generate_node_command` appends for the world.
+
+        ``--dp-size`` is deliberately absent: whether it is legal is a property
+        of the *launch* rather than of the recipe (see ``_append_dp_size``), and
+        a recipe writing it in ``command:`` is the documented DP-attention
+        spelling that ``_dp_attention_enabled`` reads back.
+        """
+        return ("--dist-init-addr", "--nnodes", "--node-rank")
+
     def native_rendezvous_port(
         self,
         recipe: "Recipe | None",

--- a/src/sparkrun/runtimes/vllm_distributed.py
+++ b/src/sparkrun/runtimes/vllm_distributed.py
@@ -52,6 +52,25 @@ class VllmDistributedRuntime(VllmMixin, RuntimePlugin):
     # override returning ``None`` for that regime (see SglangRuntime, #284).
     # Needs a live 2-node ``--dp 2`` run to confirm before changing anything.
 
+    def managed_rendezvous_flags(self) -> tuple[str, ...]:
+        """Torch-distributed (intra-replica) plus vLLM data-parallel (inter-replica).
+
+        ``--data-parallel-size`` is deliberately absent: it is the one flag in
+        this block :meth:`generate_node_command` injects *only when the template
+        did not already supply it*, so writing it is a supported choice rather
+        than a collision.
+        """
+        return (
+            "--nnodes",
+            "--node-rank",
+            "--master-addr",
+            "--master-port",
+            "--headless",
+            "--data-parallel-rank",
+            "--data-parallel-address",
+            "--data-parallel-rpc-port",
+        )
+
     def prepare(
         self,
         recipe: Recipe,

--- a/src/sparkrun/scripts/setup_check.sh
+++ b/src/sparkrun/scripts/setup_check.sh
@@ -8,6 +8,59 @@ set -uo pipefail
 
 WHO=$(id -un 2>/dev/null || echo unknown)
 echo "CHECK_USER=$WHO"
+echo "CHECK_UID=$(id -u 2>/dev/null || echo unknown)"
+
+# --- systemd-logind IPC reaping ---
+# `RemoveIPC=yes` (the Ubuntu 24.04 / DGX OS default) makes logind delete every
+# POSIX semaphore, shared-memory segment and message queue owned by a regular
+# UID once that user's last session ends. That reaps a detached workload's own
+# IPC whenever it shares the host's namespace -- an `ipc: host` container run
+# as the SSH user, or the `local` executor, which has no namespace at all.
+# Enabled lingering keeps the user manager alive and suppresses the reap.
+#
+# Read the *effective* value from logind over D-Bus first (config lives across
+# logind.conf + logind.conf.d and defaults to yes when unset, so parsing one
+# file answers a different question); fall back to the config, then to
+# "unknown". Every probe here is read-only and works unprivileged.
+_REMOVE_IPC=unknown
+if command -v busctl >/dev/null 2>&1; then
+    # NOTE no awk/sed braces anywhere in this script -- it is delivered through
+    # str.format() (for {peers}), so a literal brace raises KeyError at render.
+    _RI=$(busctl get-property org.freedesktop.login1 /org/freedesktop/login1 \
+              org.freedesktop.login1.Manager RemoveIPC 2>/dev/null | cut -d' ' -f2 | tr -d '[:space:]')
+    case "$_RI" in
+        true) _REMOVE_IPC=yes ;;
+        false) _REMOVE_IPC=no ;;
+    esac
+fi
+if [ "$_REMOVE_IPC" = unknown ] && [ -d /run/systemd/system ]; then
+    # Last uncommented RemoveIPC= across the drop-in set wins for our purposes;
+    # absent means the built-in default, which is yes.
+    _RI=$(grep -hiE '^[[:space:]]*RemoveIPC[[:space:]]*=' \
+              /etc/systemd/logind.conf /etc/systemd/logind.conf.d/*.conf \
+              /run/systemd/logind.conf.d/*.conf /usr/lib/systemd/logind.conf.d/*.conf 2>/dev/null \
+              | tail -n 1 | cut -d= -f2 | tr -d '[:space:]' | tr 'A-Z' 'a-z')
+    case "$_RI" in
+        no|false|0|off) _REMOVE_IPC=no ;;
+        yes|true|1|on) _REMOVE_IPC=yes ;;
+        *) _REMOVE_IPC=yes ;;
+    esac
+fi
+echo "CHECK_LOGIND_REMOVE_IPC=$_REMOVE_IPC"
+
+_LINGER=unknown
+if command -v loginctl >/dev/null 2>&1; then
+    _LG=$(loginctl show-user "$WHO" --property=Linger --value 2>/dev/null)
+    case "$_LG" in
+        yes) _LINGER=1 ;;
+        no) _LINGER=0 ;;
+    esac
+fi
+if [ "$_LINGER" = unknown ] && [ -d /var/lib/systemd/linger ]; then
+    # The marker directory is world-readable, so this works without a session.
+    if [ -e "/var/lib/systemd/linger/$WHO" ]; then _LINGER=1; else _LINGER=0; fi
+fi
+echo "CHECK_LOGIND_LINGER=$_LINGER"
 
 # --- Docker ---
 if command -v docker >/dev/null 2>&1; then

--- a/src/sparkrun/telemetry/util.py
+++ b/src/sparkrun/telemetry/util.py
@@ -175,8 +175,22 @@ def system_info() -> TelemetryEvent:
     }
 
 
+def registry_is_plugin_declared(entry) -> bool:
+    """Return whether a registry came from a plugin declaration, not the user."""
+    return bool(attr_string(entry, "declared_by"))
+
+
 def registry_is_default(entry) -> bool:
-    """Return whether a configured registry matches a built-in/default registry."""
+    """Return whether a configured registry matches a built-in/default registry.
+
+    A plugin-declared registry counts as default.  ``non_default_*`` means "the
+    user added a third-party registry", and a first-party plugin contributing
+    its own is not that — without this, enabling a shipped plugin would flip
+    ``has_non_default_registries`` and silently change the meaning of a metric
+    already in published series.  They are counted separately below instead.
+    """
+    if registry_is_plugin_declared(entry):
+        return True
     name = attr_string(entry, "name")
     url = attr_string(entry, "url")
     if name in _DEFAULT_REGISTRY_NAMES:
@@ -190,12 +204,14 @@ def registry_summary(registries: Sequence) -> TelemetryEvent:
     enabled = [entry for entry in registries if bool(getattr(entry, "enabled", True))]
     non_default = [entry for entry in registries if not registry_is_default(entry)]
     enabled_non_default = [entry for entry in enabled if not registry_is_default(entry)]
+    plugin_declared = [entry for entry in registries if registry_is_plugin_declared(entry)]
     return {
         "registry_count": total,
         "enabled_registry_count": len(enabled),
         "non_default_registry_count": len(non_default),
         "enabled_non_default_registry_count": len(enabled_non_default),
         "has_non_default_registries": bool(non_default),
+        "plugin_registry_count": len(plugin_declared),
     }
 
 

--- a/src/sparkrun/utils/cli_formatters.py
+++ b/src/sparkrun/utils/cli_formatters.py
@@ -575,6 +575,18 @@ def _wrap(text: str, width: int, indent: str) -> list[str]:
     )
 
 
+def timing_tree_depth_for_verbosity(verbosity: int | bool = 0) -> int | None:
+    """Map global CLI verbosity to the standard timing-tree depth.
+
+    Default output shows two levels, ``-v`` shows three, ``-vv`` shows four,
+    and ``-vvv`` (or greater) removes the limit. Quiet mode uses the compact
+    default depth if a caller explicitly requests a timing table.
+    """
+    if isinstance(verbosity, bool):
+        verbosity = 1 if verbosity else 0
+    return None if verbosity >= 3 else max(2, 2 + verbosity)
+
+
 def format_launch_timings(
     export: dict,
     *,

--- a/src/sparkrun/utils/cli_formatters.py
+++ b/src/sparkrun/utils/cli_formatters.py
@@ -575,13 +575,24 @@ def _wrap(text: str, width: int, indent: str) -> list[str]:
     )
 
 
-def format_launch_timings(export: dict, *, width: int = 62, title: str = "Launch timings") -> str:
+def format_launch_timings(
+    export: dict,
+    *,
+    width: int = 62,
+    title: str = "Launch timings",
+    max_depth: int | None = None,
+) -> str:
     """Render a :meth:`~sparkrun.core.timing.Timeline.export` as a tree.
 
     Spans nest by parent id rather than by name, because fan-out spans
     repeat their name (one per host / per distribution entry) and a
     name-keyed tree would collapse them into one row.
+
+    ``max_depth`` counts displayed levels starting at one for root spans.
+    Deeper descendants are omitted. ``None`` leaves the tree unbounded.
     """
+    if max_depth is not None and max_depth < 1:
+        raise ValueError("max_depth must be at least 1")
     spans = export.get("spans") or []
     if not spans:
         return ""
@@ -619,9 +630,14 @@ def format_launch_timings(export: dict, *, width: int = 62, title: str = "Launch
             clock = span.get("clock")
             if clock:
                 timing += "  [%s]" % clock
+            if attrs.get("composition") == "non_additive":
+                semantics = str(attrs.get("timing_semantics") or "aggregate").replace("_", " ")
+                timing += "  [%s; non-additive]" % semantics
             pad = max(1, width - len(indent) - len(label))
             lines.append("%s%s%s%s" % (indent, label, " " * pad, timing))
-            walk(span.get("id"), depth + 1)
+            displayed_depth = depth + 1
+            if max_depth is None or displayed_depth < max_depth:
+                walk(span.get("id"), depth + 1)
 
     walk(None, 0)
     return "\n".join(lines)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,10 +170,10 @@ def tmp_recipe_dir(tmp_path: Path) -> Path:
     recipe_dir = tmp_path / "recipes"
     recipe_dir.mkdir()
 
-    # v2 vllm recipe
+    # v2 vllm recipe. No ``name:`` — it is the v1 spelling, ignored on load
+    # (the name comes from the filename), and reported as a deprecation for v2.
     v2_vllm = {
         "sparkrun_version": "2",
-        "name": "Test vLLM Recipe",
         "description": "A test recipe for vLLM",
         "model": "meta-llama/Llama-2-7b-hf",
         "runtime": "vllm",
@@ -196,7 +196,6 @@ def tmp_recipe_dir(tmp_path: Path) -> Path:
     # v2 sglang recipe
     v2_sglang = {
         "sparkrun_version": "2",
-        "name": "Test SGLang Recipe",
         "description": "A test recipe for SGLang",
         "model": "meta-llama/Llama-2-7b-hf",
         "runtime": "sglang",
@@ -272,7 +271,6 @@ def sample_v2_recipe_data() -> dict[str, Any]:
     """
     return {
         "sparkrun_version": "2",
-        "name": "Sample vLLM Recipe",
         "description": "A sample vLLM recipe for testing",
         "model": "meta-llama/Llama-2-7b-hf",
         "runtime": "vllm",
@@ -338,7 +336,6 @@ def sample_sglang_recipe_data() -> dict[str, Any]:
     """
     return {
         "sparkrun_version": "2",
-        "name": "Sample SGLang Recipe",
         "description": "A sample SGLang recipe for testing",
         "model": "meta-llama/Llama-2-7b-hf",
         "runtime": "sglang",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,12 @@ def isolate_stateful(tmp_path: Path, monkeypatch):
     from sparkrun.models.hub import reset_hub_state
 
     reset_hub_state()
+    # Plugin-declared registries are a process-global overlay, so a test that
+    # declares one would otherwise add it to every later test's registry list --
+    # the same ordering-dependent failure class as the Hub state above.
+    from sparkrun.core.registry_defaults import reset_declared_registries
+
+    reset_declared_registries()
     # ...and block the send itself, because the env var above is only policy.
     # Any test can drop it (test_telemetry.py does, on purpose), and telemetry
     # fails *open*: a MagicMock config makes `telemetry_enabled` return True,

--- a/tests/test_api_run_eviction.py
+++ b/tests/test_api_run_eviction.py
@@ -209,6 +209,24 @@ def test_status_query_failure_is_swallowed(cluster):
         )
 
 
+def test_strict_status_query_failure_aborts(cluster):
+    with patch(
+        "sparkrun.orchestration.executor.query_status_for_cluster",
+        side_effect=RuntimeError("hosts unreachable"),
+    ):
+        with pytest.raises(RuntimeError, match="could not query cluster status"):
+            _evict_superseded_deployments(
+                intent_id=INTENT,
+                cluster_id_for_launch=NEW,
+                candidate_hosts=list(cluster.hosts),
+                target_hosts=list(cluster.hosts),
+                cluster_def=cluster,
+                config=None,
+                sctx=None,
+                strict=True,
+            )
+
+
 def test_stop_failure_is_swallowed(cluster):
     status = _status(("h1", [_workload(PRIOR, INTENT)]))
 
@@ -216,6 +234,26 @@ def test_stop_failure_is_swallowed(cluster):
 
     assert evicted == []
     assert len(calls) == 1  # attempted, then gave up on that deployment
+
+
+def test_strict_stop_failure_aborts(cluster):
+    status = _status(("h1", [_workload(PRIOR, INTENT)]))
+
+    with (
+        patch("sparkrun.orchestration.executor.query_status_for_cluster", return_value=status),
+        patch.object(api, "stop", side_effect=RuntimeError("ssh down")),
+    ):
+        with pytest.raises(RuntimeError, match="could not stop earlier deployment"):
+            _evict_superseded_deployments(
+                intent_id=INTENT,
+                cluster_id_for_launch=NEW,
+                candidate_hosts=list(cluster.hosts),
+                target_hosts=["h1"],
+                cluster_def=cluster,
+                config=None,
+                sctx=None,
+                strict=True,
+            )
 
 
 def test_unconfirmed_teardown_still_counts_as_attempted(cluster, caplog):
@@ -233,6 +271,26 @@ def test_unconfirmed_teardown_still_counts_as_attempted(cluster, caplog):
 
     assert evicted == [PRIOR]
     assert "did not confirm" in caplog.text
+
+
+def test_strict_unconfirmed_teardown_aborts(cluster):
+    status = _status(("h1", [_workload(PRIOR, INTENT)]))
+
+    with (
+        patch("sparkrun.orchestration.executor.query_status_for_cluster", return_value=status),
+        patch.object(api, "stop", return_value=_StopPartial(PRIOR, ["h1"])),
+    ):
+        with pytest.raises(RuntimeError, match="was not confirmed on h1"):
+            _evict_superseded_deployments(
+                intent_id=INTENT,
+                cluster_id_for_launch=NEW,
+                candidate_hosts=list(cluster.hosts),
+                target_hosts=["h1"],
+                cluster_def=cluster,
+                config=None,
+                sctx=None,
+                strict=True,
+            )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_benchmark_arena_flow.py
+++ b/tests/test_benchmark_arena_flow.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import click
+import pytest
+import yaml
 from click.testing import CliRunner
 
 from sparkrun.cli._benchmark import benchmark as benchmark_group
@@ -48,7 +52,7 @@ def test_arena_flag_triggers_preflight_and_finalize():
         captured["kwargs"].update(kwargs)
         return _fake_bench_result()
 
-    def _fake_preflight(*, local_test, ctx):
+    def _fake_preflight(*, local_test, ctx, recipe_name=None, dry_run=False):
         captured["order"].append("preflight")
         return ("sub-test-123", "@official/spark-arena-v2")
 
@@ -145,7 +149,7 @@ def test_arena_benchmark_run_uses_same_arena_flow_helpers():
         order.append("run_benchmark")
         return _fake_bench_result()
 
-    def _fake_preflight(*, local_test, ctx):
+    def _fake_preflight(*, local_test, ctx, recipe_name=None, dry_run=False):
         order.append("preflight")
         return ("s", "@official/spark-arena-v2")
 
@@ -315,3 +319,148 @@ def test_arena_flow_exports():
     assert hasattr(m, "finalize_arena")
     assert hasattr(m, "persist_arena_extras")
     assert hasattr(m, "ARENA_BENCHMARK_PROFILE")
+
+
+# --------------------------------------------------------------------------
+# Pre-submission validation gate
+# --------------------------------------------------------------------------
+#
+# The arena paths publish the recipe, so they show the *full* `recipe validate`
+# report — suggestions included — and ask before proceeding. Ordinary
+# `sparkrun benchmark` publishes nothing and keeps the launch-path contract
+# (`validate_for_launch`: suggestions withheld, deprecations collapsed).
+
+_CLEAN_RECIPE = {
+    "model": "Qwen/Qwen3-1.7B",
+    "runtime": "vllm-distributed",
+    "container": "vllm/vllm-openai:latest",
+    "defaults": {"port": 8000},
+    "command": "vllm serve {model} --port {port}",
+}
+
+# `name:` -> deprecated-recipe-name (warning);
+# literal model id -> restated-model-arg (suggestion).
+_MESSY_RECIPE = {
+    **_CLEAN_RECIPE,
+    "name": "Arena Demo",
+    "command": "vllm serve Qwen/Qwen3-1.7B --port {port}",
+}
+
+_ERROR_RECIPE = {"runtime": "vllm-distributed", "container": "x:latest"}  # no model:
+
+
+def _write(tmp_path: Path, data: dict) -> str:
+    path = tmp_path / "arena-demo.yaml"
+    path.write_text(yaml.safe_dump(data))
+    return str(path)
+
+
+def _gate(recipe_path: str, *, tty: bool, answer: str | None = None, dry_run: bool = False):
+    """Run the gate under a Click context, returning (exit_code, output)."""
+    from sparkrun.cli._arena_flow import validate_recipe_for_submission
+
+    runner = CliRunner()
+
+    @click.command()
+    def _cmd():
+        validate_recipe_for_submission(recipe_path, ctx=click.get_current_context(), dry_run=dry_run)
+        click.echo("PROCEEDED")
+
+    with patch("sparkrun.cli._arena_flow._is_interactive", lambda: tty):
+        result = runner.invoke(_cmd, [], input=answer)
+    return result
+
+
+def test_clean_recipe_says_nothing_and_does_not_prompt(tmp_path):
+    """A report with no findings is noise between the user and their benchmark."""
+    result = _gate(_write(tmp_path, _CLEAN_RECIPE), tty=True)
+    assert result.exit_code == 0
+    assert "PROCEEDED" in result.output
+    assert "We suggest" not in result.output
+
+
+def test_findings_are_shown_in_full_including_suggestions(tmp_path):
+    """The whole point of the gate: `validate_for_launch` withholds suggestions,
+    and a recipe about to be published is exactly when its author needs them."""
+    result = _gate(_write(tmp_path, _MESSY_RECIPE), tty=True, answer="y\n")
+    assert "warning  deprecated-recipe-name" in result.output
+    assert "suggestion  restated-model-arg" in result.output
+    assert "The recipe contains 1 warning and 1 suggestion." in result.output
+    assert "may not be published to Spark Arena" in result.output
+    assert "PROCEEDED" in result.output
+
+
+def test_declining_the_prompt_aborts(tmp_path):
+    result = _gate(_write(tmp_path, _MESSY_RECIPE), tty=True, answer="n\n")
+    assert result.exit_code == 1
+    assert "PROCEEDED" not in result.output
+
+
+def test_prompt_defaults_to_no(tmp_path):
+    """Bare Enter must not submit a recipe the user was just warned about."""
+    result = _gate(_write(tmp_path, _MESSY_RECIPE), tty=True, answer="\n")
+    assert result.exit_code == 1
+    assert "PROCEEDED" not in result.output
+
+
+def test_non_interactive_proceeds_with_a_notice(tmp_path):
+    """Quality advice, not a security gate — the hook trust prompt is the one
+    that refuses without a TTY. Aborting here would break a scripted
+    submission that worked yesterday."""
+    result = _gate(_write(tmp_path, _MESSY_RECIPE), tty=False)
+    assert result.exit_code == 0
+    assert "Not running interactively" in result.output
+    assert "PROCEEDED" in result.output
+
+
+def test_errors_abort_without_prompting(tmp_path):
+    """The launch would refuse anyway; "continue?" is not a real question when
+    the answer cannot be yes."""
+    result = _gate(_write(tmp_path, _ERROR_RECIPE), tty=True)
+    assert result.exit_code == 1
+    assert "cannot be submitted" in result.output
+    assert "Continue with the benchmark" not in result.output
+
+
+def test_dry_run_reports_but_does_not_prompt(tmp_path):
+    result = _gate(_write(tmp_path, _MESSY_RECIPE), tty=True, dry_run=True)
+    assert result.exit_code == 0
+    assert "The recipe contains" in result.output
+    assert "[dry-run] Not prompting" in result.output
+    assert "PROCEEDED" in result.output
+
+
+@pytest.mark.parametrize(
+    "counts,expected",
+    [
+        ({"warning": 3, "suggestion": 4}, "3 warnings and 4 suggestions"),
+        ({"warning": 1, "suggestion": 0}, "1 warning"),
+        ({"warning": 0, "suggestion": 1}, "1 suggestion"),
+        ({"warning": 0, "suggestion": 2}, "2 suggestions"),
+    ],
+)
+def test_count_phrase_omits_absent_levels(counts, expected):
+    from sparkrun.cli._arena_flow import _count_phrase
+
+    assert _count_phrase({"error": 0, **counts}) == expected
+
+
+def test_local_test_still_validates(tmp_path):
+    """`--local-test` rehearses a submission; rehearsing without the checks
+    would defeat the rehearsal."""
+    from sparkrun.cli._arena_flow import preflight_arena
+
+    seen = {}
+
+    def _fake(recipe_name, *, ctx, dry_run=False):
+        seen["recipe"] = recipe_name
+
+    runner = CliRunner()
+
+    @click.command()
+    def _cmd():
+        preflight_arena(local_test=True, ctx=click.get_current_context(), recipe_name="r", dry_run=False)
+
+    with patch("sparkrun.cli._arena_flow.validate_recipe_for_submission", _fake):
+        runner.invoke(_cmd, [])
+    assert seen["recipe"] == "r"

--- a/tests/test_benchmark_hosts_and_errors.py
+++ b/tests/test_benchmark_hosts_and_errors.py
@@ -67,7 +67,12 @@ def _capture_hosts(argv, *, arena: bool):
     patches = [patch("sparkrun.api._benchmark._execute_benchmark", _fake_execute)]
     if arena:
         # Skip the arena auth/preflight round-trip; irrelevant to host parsing.
-        patches.append(patch("sparkrun.cli._arena_flow.preflight_arena", lambda local_test=False, ctx=None: ("sub-1", None)))
+        patches.append(
+            patch(
+                "sparkrun.cli._arena_flow.preflight_arena",
+                lambda local_test=False, ctx=None, recipe_name=None, dry_run=False: ("sub-1", None),
+            )
+        )
 
     with patches[0]:
         if arena:
@@ -162,7 +167,10 @@ def _capture_trust(argv, *, arena: bool):
 
     with patch("sparkrun.api._benchmark._execute_benchmark", _fake_execute):
         if arena:
-            with patch("sparkrun.cli._arena_flow.preflight_arena", lambda local_test=False, ctx=None: ("sub-1", None)):
+            with patch(
+                "sparkrun.cli._arena_flow.preflight_arena",
+                lambda local_test=False, ctx=None, recipe_name=None, dry_run=False: ("sub-1", None),
+            ):
                 CliRunner().invoke(main, argv)
         else:
             CliRunner().invoke(main, argv)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,7 +23,8 @@ _TEST_RECIPE_SOLO_NAME = "test-solo-only"
 
 _TEST_RECIPE_SOLO_DATA = {
     "recipe_version": "2",
-    "name": "Test Solo Only Recipe",
+    # No `name:` either — it is the v1 spelling, ignored on load (the name is
+    # the filename), and reported as `deprecated-recipe-name` for v2.
     "description": "A test recipe capped at max_nodes=1",
     "model": "Qwen/Qwen3-1.7B",
     "runtime": "sglang",
@@ -41,7 +42,7 @@ _TEST_RECIPE_NAME = "test-sglang-cluster"
 
 _TEST_RECIPE_DATA = {
     "sparkrun_version": "2",
-    "name": "Test SGLang Cluster Recipe",
+    # Likewise no `name:` — see above.
     "description": "A test recipe for CLI integration tests",
     "model": "Qwen/Qwen3-1.7B",
     "runtime": "sglang",
@@ -228,7 +229,6 @@ class TestSearchCommand:
         (tmp_path / "cwd-llama-cpp.yaml").write_text(
             yaml.safe_dump(
                 {
-                    "name": "cwd-llama-cpp",
                     "model": "unsloth/Qwen3-1.7B-GGUF:Q4_K_M",
                     "runtime": "llama-cpp",
                     # discover_cwd_recipes -> is_recipe_file requires container

--- a/tests/test_cli_cluster_inspect.py
+++ b/tests/test_cli_cluster_inspect.py
@@ -1,0 +1,130 @@
+"""CLI tests for ``sparkrun cluster inspect`` — head-node hardware reporting."""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from sparkrun.cli import main
+from sparkrun.orchestration.disk_info import CacheStatus
+from sparkrun.orchestration.distribution import TransferModeResult
+from sparkrun.orchestration.ssh import RemoteResult
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+def _diag_stdout() -> str:
+    lines = [
+        "DIAG_HOSTNAME=spark-01",
+        "DIAG_PRODUCT_NAME=NVIDIA DGX Spark",
+        "DIAG_BOARD_NAME=DGX Spark",
+        "DIAG_BIOS_VERSION=1.2.3",
+        "DIAG_OS_PRETTY=Ubuntu 24.04 LTS",
+        "DIAG_KERNEL=6.11.0-1008-nvidia",
+        "DIAG_ARCH=aarch64",
+        "DIAG_CPU_MODEL=ARM Neoverse",
+        "DIAG_CPU_CORES=20",
+        "DIAG_CPU_THREADS=20",
+        "DIAG_RAM_TOTAL_KB=131072000",
+        "DIAG_GPU_NAME=NVIDIA GB10",
+        "DIAG_GPU_MEMORY_MB=122880",
+        "DIAG_GPU_DRIVER=580.95.05",
+        "DIAG_CUDA_VERSION=13.0",
+        "DIAG_JETPACK_VERSION=6.2",
+        "DIAG_DOCKER_VERSION=28.1.1",
+        "DIAG_DOCKER_STORAGE=overlay2",
+        "DIAG_DOCKER_NVIDIA_RUNTIME=true",
+        "DIAG_NET_COUNT=0",
+        "DIAG_COMPLETE=1",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+class _InspectMocks:
+    """Patch every SSH-touching call ``cluster inspect`` makes."""
+
+    def __init__(self, diag_results):
+        self._diag_results = diag_results
+        self._patches = []
+
+    def __enter__(self):
+        targets = [
+            mock.patch("sparkrun.core.launcher.resolve_effective_cache_dir", return_value="/home/u/.cache/huggingface"),
+            mock.patch(
+                "sparkrun.orchestration.distribution.resolve_auto_transfer_mode",
+                return_value=TransferModeResult(mode="delegated"),
+            ),
+            mock.patch("sparkrun.orchestration.infiniband.detect_ib_for_hosts", return_value=None),
+            mock.patch(
+                "sparkrun.orchestration.disk_info.probe_cache_status",
+                return_value={"10.0.0.1": CacheStatus(host="10.0.0.1")},
+            ),
+            mock.patch("sparkrun.diagnostics.spark_collector.read_script", return_value="#!/bin/bash\necho ok"),
+            mock.patch(
+                "sparkrun.diagnostics.spark_collector.run_remote_scripts_parallel",
+                return_value=self._diag_results,
+            ),
+        ]
+        for p in targets:
+            p.start()
+            self._patches.append(p)
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._patches):
+            p.stop()
+        return False
+
+
+def test_inspect_reports_head_node_hardware(runner, v):
+    results = [RemoteResult(host="10.0.0.1", returncode=0, stdout=_diag_stdout(), stderr="")]
+    with _InspectMocks(results):
+        result = runner.invoke(main, ["cluster", "inspect", "--hosts", "10.0.0.1"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "Head Node Hardware (10.0.0.1):" in result.output
+    assert "NVIDIA DGX Spark" in result.output
+    assert "Ubuntu 24.04 LTS (kernel 6.11.0-1008-nvidia, aarch64)" in result.output
+    assert "580.95.05" in result.output
+    assert "13.0" in result.output
+    assert "28.1.1 (storage: overlay2, nvidia runtime: yes)" in result.output
+
+
+def test_inspect_head_hardware_json(runner, v):
+    results = [RemoteResult(host="10.0.0.1", returncode=0, stdout=_diag_stdout(), stderr="")]
+    with _InspectMocks(results):
+        result = runner.invoke(main, ["cluster", "inspect", "--hosts", "10.0.0.1", "--json"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    data = json.loads(result.output)
+    head = data["head_node"]
+    assert head["host"] == "10.0.0.1"
+    assert head["hardware"]["gpu_driver"] == "580.95.05"
+    assert head["hardware"]["gpu_memory_gb"] == 120.0
+    assert head["hardware"]["os"] == "Ubuntu 24.04 LTS"
+
+
+def test_inspect_survives_failed_hardware_probe(runner, v):
+    """A failed probe must not take down the rest of the report."""
+    results = [RemoteResult(host="10.0.0.1", returncode=255, stdout="", stderr="connection refused")]
+    with _InspectMocks(results):
+        result = runner.invoke(main, ["cluster", "inspect", "--hosts", "10.0.0.1"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "hardware probe failed" in result.output
+    assert "Cache Paths:" in result.output
+
+
+def test_inspect_dry_run_skips_hardware_probe(runner, v):
+    with _InspectMocks([]) as mocks:  # noqa: F841
+        result = runner.invoke(main, ["cluster", "inspect", "--hosts", "10.0.0.1", "--dry-run"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert "[dry-run] Would probe head node hardware on 10.0.0.1" in result.output
+    assert "Head Node Hardware" not in result.output

--- a/tests/test_cluster_manager.py
+++ b/tests/test_cluster_manager.py
@@ -22,6 +22,70 @@ def test_create_cluster(tmp_path: Path):
     assert cluster.description == "Test description"
 
 
+def test_cluster_sparkrun_cache_and_plugin_policy_round_trip_independently(tmp_path: Path):
+    from sparkrun.core.cluster_manager import ClusterDefinition
+
+    manager = ClusterManager(tmp_path)
+    manager._write_cluster(
+        ClusterDefinition(
+            name="storage-policy",
+            hosts=["host1", "host2"],
+            cache_dir="/mnt/shared/huggingface",
+            sparkrun_cache_dir="/mnt/local/sparkrun",
+            plugins={
+                "coldsnap": {
+                    "state_root": "/mnt/local/coldsnap",
+                    "io": {"recovery_read": "buffered"},
+                }
+            },
+        )
+    )
+
+    cluster = manager.get("storage-policy")
+    assert cluster.cache_dir == "/mnt/shared/huggingface"
+    assert cluster.sparkrun_cache_dir == "/mnt/local/sparkrun"
+    assert cluster.plugin_settings("coldsnap") == {
+        "state_root": "/mnt/local/coldsnap",
+        "io": {"recovery_read": "buffered"},
+    }
+    exported = cluster.to_dict()
+    assert exported["sparkrun_cache_dir"] == "/mnt/local/sparkrun"
+    assert exported["plugins"]["coldsnap"]["state_root"] == "/mnt/local/coldsnap"
+
+
+def test_cluster_create_and_update_preserve_sparkrun_cache_and_plugin_policy(tmp_path: Path):
+    manager = ClusterManager(tmp_path)
+    manager.create(
+        "managed-policy",
+        ["host1"],
+        sparkrun_cache_dir="/mnt/sparkrun-a",
+        plugins={"coldsnap": {"io": {"recovery_read": "buffered"}}},
+    )
+    created = manager.get("managed-policy")
+    assert created.sparkrun_cache_dir == "/mnt/sparkrun-a"
+    assert created.plugin_settings("coldsnap")["io"]["recovery_read"] == "buffered"
+
+    manager.update(
+        "managed-policy",
+        sparkrun_cache_dir="/mnt/sparkrun-b",
+        plugins={"coldsnap": {"state_root": "/mnt/coldsnap"}},
+    )
+    updated = manager.get("managed-policy")
+    assert updated.sparkrun_cache_dir == "/mnt/sparkrun-b"
+    assert updated.plugin_settings("coldsnap") == {"state_root": "/mnt/coldsnap"}
+
+
+def test_cluster_plugin_policy_rejects_plugin_discovery_paths(tmp_path: Path):
+    root = tmp_path / "clusters"
+    root.mkdir()
+    (root / "invalid.yaml").write_text(
+        "name: invalid\nhosts: [host1]\nplugins:\n  coldsnap:\n    paths: [/tmp/plugin]\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ClusterError, match="cannot declare plugin discovery paths"):
+        ClusterManager(tmp_path).get("invalid")
+
+
 def test_create_cluster_already_exists(tmp_path: Path):
     """Creating a cluster with an existing name raises ClusterError."""
     manager = ClusterManager(tmp_path)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -15,6 +15,7 @@ from sparkrun.diagnostics.spark_collector import (
     collect_config_diagnostics,
     collect_spark_diagnostics,
     collect_sudo_diagnostics,
+    summarize_host_diagnostics,
 )
 from sparkrun.diagnostics.run_collector import RunDiagnosticsCollector
 from sparkrun.orchestration.ssh import RemoteResult
@@ -176,6 +177,85 @@ class TestSparkCollectorHelpers:
 
     def test_extract_firmware_history_empty(self):
         assert _extract_firmware_history({}) == []
+
+
+# ---------------------------------------------------------------------------
+# summarize_host_diagnostics
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizeHostDiagnostics:
+    def test_summary_fields(self):
+        kv = {
+            "DIAG_HOSTNAME": "spark-01",
+            "DIAG_PRODUCT_NAME": "NVIDIA DGX Spark",
+            "DIAG_BOARD_NAME": "DGX Spark",
+            "DIAG_BIOS_VERSION": "1.0",
+            "DIAG_OS_PRETTY": "Ubuntu 24.04 LTS",
+            "DIAG_OS_NAME": "Ubuntu",
+            "DIAG_KERNEL": "6.11.0-1008-nvidia",
+            "DIAG_ARCH": "aarch64",
+            "DIAG_CPU_MODEL": "ARM Neoverse",
+            "DIAG_CPU_CORES": "20",
+            "DIAG_CPU_THREADS": "20",
+            "DIAG_RAM_TOTAL_KB": "131072000",
+            "DIAG_GPU_NAME": "NVIDIA GB10",
+            "DIAG_GPU_MEMORY_MB": "122880",
+            "DIAG_GPU_DRIVER": "580.95.05",
+            "DIAG_CUDA_VERSION": "13.0",
+            "DIAG_JETPACK_VERSION": "6.2",
+            "DIAG_DOCKER_VERSION": "28.1.1",
+            "DIAG_DOCKER_STORAGE": "overlay2",
+            "DIAG_DOCKER_NVIDIA_RUNTIME": "true",
+        }
+        summary = summarize_host_diagnostics(kv)
+
+        assert summary["hostname"] == "spark-01"
+        assert summary["product"] == "NVIDIA DGX Spark"
+        assert summary["os"] == "Ubuntu 24.04 LTS"
+        assert summary["kernel"] == "6.11.0-1008-nvidia"
+        assert summary["cpu_cores"] == 20
+        assert summary["ram_total_gb"] == 125.0
+        assert summary["gpu_name"] == "NVIDIA GB10"
+        assert summary["gpu_memory_gb"] == 120.0
+        assert summary["gpu_driver"] == "580.95.05"
+        assert summary["cuda_version"] == "13.0"
+        assert summary["docker_nvidia_runtime"] is True
+
+    def test_empty_values_omitted(self):
+        # The probe emits a key for everything it looks for; "no nvcc here"
+        # must not render as a blank CUDA line.
+        summary = summarize_host_diagnostics(
+            {
+                "DIAG_GPU_NAME": "NVIDIA GB10",
+                "DIAG_CUDA_VERSION": "",
+                "DIAG_JETPACK_VERSION": "",
+                "DIAG_RAM_TOTAL_KB": "0",
+                "DIAG_DOCKER_VERSION": "",
+            }
+        )
+        assert "cuda_version" not in summary
+        assert "jetpack_version" not in summary
+        assert "ram_total_gb" not in summary
+        assert "docker_version" not in summary
+        assert summary["gpu_name"] == "NVIDIA GB10"
+
+    def test_failed_probe_yields_empty_summary(self):
+        assert summarize_host_diagnostics({}) == {}
+
+    def test_os_falls_back_to_name(self):
+        summary = summarize_host_diagnostics({"DIAG_OS_NAME": "Ubuntu", "DIAG_OS_PRETTY": ""})
+        assert summary["os"] == "Ubuntu"
+
+    def test_non_numeric_counts_ignored(self):
+        summary = summarize_host_diagnostics({"DIAG_CPU_CORES": "unknown", "DIAG_GPU_MEMORY_MB": ""})
+        assert "cpu_cores" not in summary
+        assert "gpu_memory_gb" not in summary
+
+    def test_identifiers_excluded(self):
+        # Serial / UUID identify a specific unit — deliberately not summarised.
+        summary = summarize_host_diagnostics({"DIAG_GPU_SERIAL": "1234", "DIAG_GPU_UUID": "GPU-abc"})
+        assert summary == {}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -19,7 +19,7 @@ from sparkrun.orchestration.executor import (
     Executor,
     ExecutorConfig,
 )
-from sparkrun.orchestration.executors.docker import DockerExecutor
+from sparkrun.orchestration.executors.docker import DockerExecutor, _warn_host_ipc_reaper
 from sparkrun.utils.shell import b64_encode_cmd
 
 
@@ -37,7 +37,7 @@ class TestExecutorConfig:
         assert cfg.restart_policy is None
         assert cfg.privileged is True
         assert cfg.gpus == "all"
-        assert cfg.ipc == "host"
+        assert cfg.ipc == "shareable"
         assert cfg.shm_size == "25gb"
         assert cfg.network == "host"
 
@@ -222,6 +222,18 @@ class TestDockerExecutorConfig:
         cmd = executor.run_cmd("img:latest")
         assert "--restart on-failure:3" in cmd
         assert "--rm" not in cmd
+
+    def test_default_ipc_is_shareable(self):
+        cmd = DockerExecutor().run_cmd("img:latest")
+        assert "--ipc=shareable" in cmd
+        assert "--ipc=host" not in cmd
+
+    def test_default_shm_size_is_emitted_and_effective(self):
+        # Docker ignores --shm-size under --ipc=host, so this flag only means
+        # anything because the ipc default is a container-owned namespace.
+        cmd = DockerExecutor(ExecutorConfig.from_chain(DockerExecutor.default_config())).run_cmd("img:latest")
+        assert "--ipc=shareable" in cmd
+        assert "--shm-size=32gb" in cmd
 
     def test_custom_shm_size(self):
         cfg = ExecutorConfig(shm_size="20gb")
@@ -542,3 +554,53 @@ class TestEnvDebugMasking:
 
         dump_lines = [r.getMessage() for r in caplog.records if r.getMessage().startswith("  ")]
         assert "  VLLM_LOGGING_LEVEL=INFO" in "\n".join(dump_lines)
+
+
+# ---------------------------------------------------------------------------
+# Host-IPC advisory (issue #285)
+# ---------------------------------------------------------------------------
+
+
+class TestHostIpcAdvisory:
+    """``ipc: host`` + a non-root container user is reapable by systemd-logind.
+
+    The combination is legal and sometimes wanted (cross-container shared
+    memory on one host), so it warns rather than refusing — but silence would
+    leave the operator to rediscover an intermittent, timing-dependent startup
+    failure from first principles.
+    """
+
+    @staticmethod
+    def _run(cfg, caplog):
+        _warn_host_ipc_reaper.cache_clear()
+        with caplog.at_level(logging.WARNING, logger="sparkrun.orchestration.executors.docker"):
+            DockerExecutor(cfg).run_cmd("img:latest")
+        return caplog.text
+
+    def test_warns_for_auto_user(self, caplog):
+        text = self._run(ExecutorConfig(ipc="host", user="$SHELL_USER"), caplog)
+        assert "RemoveIPC" in text
+        assert "enable-linger" in text
+
+    def test_warns_for_explicit_non_root_uid(self, caplog):
+        assert "RemoveIPC" in self._run(ExecutorConfig(ipc="host", user="1000:1000"), caplog)
+
+    def test_silent_for_root_user(self, caplog):
+        assert "RemoveIPC" not in self._run(ExecutorConfig(ipc="host", user="root"), caplog)
+        assert "RemoveIPC" not in self._run(ExecutorConfig(ipc="host", user="0:0"), caplog)
+
+    def test_silent_when_no_user_is_requested(self, caplog):
+        # No --user means the image's own user, which is root for the images
+        # sparkrun runs against — logind never reaps system UIDs.
+        assert "RemoveIPC" not in self._run(ExecutorConfig(ipc="host"), caplog)
+
+    def test_silent_on_the_default_namespace(self, caplog):
+        assert "RemoveIPC" not in self._run(ExecutorConfig(user="$SHELL_USER"), caplog)
+
+    def test_warns_once_per_user(self, caplog):
+        _warn_host_ipc_reaper.cache_clear()
+        cfg = ExecutorConfig(ipc="host", user="$SHELL_USER")
+        with caplog.at_level(logging.WARNING, logger="sparkrun.orchestration.executors.docker"):
+            for _ in range(4):  # one per node of a 4-node launch
+                DockerExecutor(cfg).run_cmd("img:latest")
+        assert sum(1 for r in caplog.records if "RemoveIPC" in r.getMessage()) == 1

--- a/tests/test_executor_describe_terminated.py
+++ b/tests/test_executor_describe_terminated.py
@@ -25,7 +25,23 @@ from sparkrun.orchestration.executors.k8s import K8sExecutor
 from sparkrun.orchestration.executors.local import LocalExecutor
 from sparkrun.orchestration.ssh import RemoteResult
 from sparkrun.core.log_source import MODE_FILE, MODE_STDOUT, SERVE_LOG_PATH, LogSource
-from tests.test_log_diagnostics import ISSUE_280_LOG
+
+#: The smallest log that clears both of ``detect_in_place_write_failure``'s
+#: gates: a directory-creation frame plus an ENOENT whose path is under a
+#: Python installation tree (issue #280's shape). These tests are about the
+#: *hints* the detection produces, so this only has to trip the detector —
+#: ``test_log_diagnostics`` owns what the parser accepts.
+#:
+#: Deliberately local, not shared with that module. A sample that stopped
+#: tripping the detector would fail these assertions loudly (the hints would
+#: fall back to the generic pair), so there is nothing to keep in sync — and
+#: importing one test module from another made collection order and the pytest
+#: invocation load-bearing.
+_IN_PLACE_WRITE_CRASH = (
+    '  File "/usr/lib/python3.12/pathlib.py", line 1313, in mkdir\n'
+    "FileNotFoundError: [Errno 2] No such file or directory: "
+    "'/usr/local/lib/python3.12/dist-packages/flashinfer/data/csrc/gen'\n"
+)
 
 
 def _source(host: str, container: str) -> LogSource:
@@ -216,7 +232,9 @@ class TestPostMortemAttribution:
 
     def test_recognised_failure_names_the_fix(self):
         ex = DockerExecutor(ExecutorConfig(auto_remove=False))
-        results = [RemoteResult(host="h1", returncode=0, stdout=self._probe_output("c1", "Exited (1) ago", ISSUE_280_LOG), stderr="")]
+        results = [
+            RemoteResult(host="h1", returncode=0, stdout=self._probe_output("c1", "Exited (1) ago", _IN_PLACE_WRITE_CRASH), stderr="")
+        ]
         with patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel", return_value=results):
             info = ex.describe_terminated([_source("h1", "c1")])[("h1", "c1")]
 
@@ -229,7 +247,9 @@ class TestPostMortemAttribution:
     def test_attribution_precedes_the_generic_hints(self):
         """It names a *likely* cause — the operator still wants the raw log."""
         ex = DockerExecutor(ExecutorConfig(auto_remove=False))
-        results = [RemoteResult(host="h1", returncode=0, stdout=self._probe_output("c1", "Exited (1) ago", ISSUE_280_LOG), stderr="")]
+        results = [
+            RemoteResult(host="h1", returncode=0, stdout=self._probe_output("c1", "Exited (1) ago", _IN_PLACE_WRITE_CRASH), stderr="")
+        ]
         with patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel", return_value=results):
             hints = ex.describe_terminated([_source("h1", "c1")])[("h1", "c1")].investigate_hints
 
@@ -261,7 +281,9 @@ class TestPostMortemAttribution:
 
     def test_a_broken_detector_never_breaks_the_post_mortem(self):
         ex = DockerExecutor(ExecutorConfig(auto_remove=False))
-        results = [RemoteResult(host="h1", returncode=0, stdout=self._probe_output("c1", "Exited (1) ago", ISSUE_280_LOG), stderr="")]
+        results = [
+            RemoteResult(host="h1", returncode=0, stdout=self._probe_output("c1", "Exited (1) ago", _IN_PLACE_WRITE_CRASH), stderr="")
+        ]
         with (
             patch("sparkrun.utils.log_diagnostics.detect_in_place_write_failure", side_effect=RuntimeError("boom")),
             patch("sparkrun.orchestration.ssh.run_remote_scripts_parallel", return_value=results),

--- a/tests/test_executor_resolution.py
+++ b/tests/test_executor_resolution.py
@@ -348,8 +348,21 @@ class TestDockerAdjustmentsApplyOnlyToDocker:
         # only when DockerExecutor is selected.
         ex = resolve_executor(rootless=False, auto_user=False)
         assert ex.config.shm_size == "32gb"
-        assert ex.config.ipc == "host"
+        assert ex.config.ipc == "shareable"
         assert ex.config.network == "host"
+
+    def test_default_ipc_survives_both_privilege_modes(self):
+        # `ipc` is orthogonal to privilege: it is not part of the rootless
+        # adjustment layer, so --rootful does not restore the host namespace.
+        # Keeping them coupled would make `shm_size` inert in one mode only
+        # (Docker ignores --shm-size under --ipc=host).
+        assert resolve_executor(rootless=True, auto_user=True).config.ipc == "shareable"
+        assert resolve_executor(rootless=False, auto_user=False).config.ipc == "shareable"
+
+    def test_recipe_can_still_pin_host_ipc(self):
+        ex = resolve_executor(recipe=_FakeRecipe(executor_config={"ipc": "host"}), rootless=True, auto_user=True)
+        assert ex.config.ipc == "host"
+        assert "--ipc=host" in ex.run_cmd("img:latest")
 
     def test_local_path_does_not_pick_up_docker_adjustments(self):
         ex = resolve_executor(
@@ -836,7 +849,7 @@ class TestFromChainDefaultPreservation:
         assert cfg.gpus == "0"
         # Untouched fields keep dataclass defaults.
         assert cfg.privileged is True
-        assert cfg.ipc == "host"
+        assert cfg.ipc == "shareable"
 
 
 # ---------------------------------------------------------------------------
@@ -887,6 +900,12 @@ class TestGoldenEquivalence:
     K8s cases in the snapshot used the pre-refactor (broken) behaviour
     of leaking Docker adjustments into non-Docker configs and are not
     re-asserted here.
+
+    One field has deliberately diverged from that snapshot since: ``ipc``
+    moved from ``host`` to ``shareable`` (issue #285 — a host IPC namespace
+    lets systemd-logind's ``RemoveIPC`` reap the workload's semaphores once
+    the launching SSH session closes).  ``shm_size`` is unchanged but only
+    takes effect now, since Docker ignores ``--shm-size`` under ``ipc=host``.
     """
 
     def test_default_docker_byte_identical(self):
@@ -898,7 +917,7 @@ class TestGoldenEquivalence:
             "auto_remove": True,
             "privileged": False,  # rootless adjustment
             "gpus": "all",
-            "ipc": "host",
+            "ipc": "shareable",
             "shm_size": "32gb",
             "network": "host",
             "user": "$SHELL_USER",

--- a/tests/test_log_diagnostics.py
+++ b/tests/test_log_diagnostics.py
@@ -16,25 +16,32 @@ from sparkrun.utils.log_diagnostics import (
     detect_in_place_write_failure,
 )
 
-#: The traceback from issue #280, verbatim.  The eugr ``vllm-node-mxfp4`` image
-#: pins a flashinfer fork whose ``gen_cutlass_fused_moe_module`` generates
-#: cutlass instantiations into ``FLASHINFER_CSRC_DIR`` — i.e. inside its own
-#: ``dist-packages`` — which works as root (legacy ``run-recipe.sh``) and
-#: cannot work under sparkrun's rootless ``--user $(id -u):$(id -g)``.
-ISSUE_280_LOG = """\
-(EngineCore_DP0 pid=481) Process EngineCore_DP0:
-(EngineCore_DP0 pid=481) Traceback (most recent call last):
-(EngineCore_DP0 pid=481)   File "/usr/lib/python3.12/pathlib.py", line 1313, in mkdir
-(EngineCore_DP0 pid=481)     os.mkdir(self, mode)
-(EngineCore_DP0 pid=481) FileNotFoundError: [Errno 2] No such file or directory: \
-'/usr/local/lib/python3.12/dist-packages/flashinfer/data/csrc/nv_internal/tensorrt_llm/cutlass_instantiations/120_mxfp4min'
-"""
+#: The two lines the detector actually reads, in the shape real output has
+#: them: a directory-creation frame (the ENOENT gate) and an errno line whose
+#: path is under a Python installation tree. Synthesized rather than a captured
+#: crash log — the surrounding frames are decoration, and a verbatim dump would
+#: be a fixture nobody can safely trim later.
+#:
+#: The ``(EngineCore_DP0 pid=NNN)`` prefix is deliberate: vLLM prefixes every
+#: worker line, so a future anchored regex would silently stop matching real
+#: logs while a bare traceback fixture kept passing.
+ENOENT_MKDIR_LOG = (
+    '(EngineCore_DP0 pid=481)   File "/usr/lib/python3.12/pathlib.py", line 1313, in mkdir\n'
+    "(EngineCore_DP0 pid=481)     os.mkdir(self, mode)\n"
+    "(EngineCore_DP0 pid=481) FileNotFoundError: [Errno 2] No such file or directory: "
+    "'/usr/local/lib/python3.12/dist-packages/flashinfer/data/csrc/cutlass_instantiations/120_mxfp4min'\n"
+)
 
 
 class TestDetectsRealSignatures:
     def test_issue_280_traceback(self):
-        """The failure this whole path exists to attribute."""
-        failure = detect_in_place_write_failure(ISSUE_280_LOG)
+        """The failure this whole path exists to attribute (issue #280).
+
+        The eugr ``vllm-node-mxfp4`` image pins a flashinfer fork that generates
+        cutlass instantiations into its own ``dist-packages`` — fine as root,
+        impossible under sparkrun's rootless ``--user $(id -u):$(id -g)``.
+        """
+        failure = detect_in_place_write_failure(ENOENT_MKDIR_LOG)
 
         assert failure is not None
         assert failure.errno == ENOENT

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -329,6 +329,25 @@ def test_progress_heartbeat_stops_at_exit(caplog):
     assert len(caplog.records) == emitted
 
 
+def test_progress_heartbeat_uses_dynamic_label(caplog):
+    """Callers can make heartbeat detail follow live operation state."""
+    import logging
+    import time
+
+    from sparkrun.core.progress import PROGRESS, progress_heartbeat
+
+    detail = {"value": "Preparing capsules"}
+    logger = logging.getLogger("sparkrun.test.heartbeat.dynamic")
+    with (
+        caplog.at_level(PROGRESS, logger="sparkrun.test.heartbeat.dynamic"),
+        progress_heartbeat(logger, lambda: detail["value"], interval=0.02),
+    ):
+        detail["value"] = "Pulling capsules on 2 nodes"
+        time.sleep(0.05)
+
+    assert "Pulling capsules on 2 nodes — still running" in caplog.text
+
+
 def test_progress_heartbeat_propagates_the_failure_it_was_watching():
     """The heartbeat is observational: it never swallows the work's error."""
     import logging

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -78,6 +78,30 @@ class TestResolveFromQuantizationConfig:
         assert info.bits == 4
         assert info.weight_dtype == "mxfp4"
 
+    def test_exl3_carries_fractional_bpw_in_the_dtype(self):
+        """Width is per-checkpoint (2.05/3.05/4.05 ship as separate branches of
+        one repo), so it cannot be a table entry and rides in the dtype string.
+        Detecting it here is what lets a recipe omit metadata.model_dtype."""
+        from sparkrun.models.dtypes import bytes_per_element
+
+        info = _resolve_from_quantization_config({"quant_method": "exl3", "bits": 2.05, "head_bits": 5})
+        assert info is not None
+        assert info.method == "exl3"
+        assert info.bits == 2.05
+        assert info.weight_dtype == "exl3:2.05"
+        assert bytes_per_element(info.weight_dtype) == 2.05 / 8
+
+    def test_exl2_uses_the_same_shape(self):
+        info = _resolve_from_quantization_config({"quant_method": "exl2", "bits": 4.25})
+        assert info is not None
+        assert info.weight_dtype == "exl2:4.25"
+
+    def test_exl3_without_bits_is_unresolved(self):
+        """No nominal default: any guess would be wrong for two of the three
+        published builds, and an unknown dtype degrades to 'no weight estimate'
+        rather than to a confidently wrong one."""
+        assert _resolve_from_quantization_config({"quant_method": "exl3"}) is None
+
     def test_nvfp4(self):
         info = _resolve_from_quantization_config({"quant_method": "nvfp4"})
         assert info is not None

--- a/tests/test_rebuild_force_pull.py
+++ b/tests/test_rebuild_force_pull.py
@@ -267,20 +267,24 @@ class TestRebuildDerivedFromRecipe:
     """``--rebuild`` reaches distribution as ``builder_config.rebuild``."""
 
     @pytest.mark.parametrize(
-        "builder_config,expected",
+        "builder,builder_config,expected",
         [
-            ({"rebuild": True}, True),
-            ({"rebuild": False}, False),
-            ({}, False),
-            (None, False),
+            ("", {"rebuild": True}, True),
+            ("docker-pull", {"rebuild": True}, True),
+            ("coldsnap", {"rebuild": True}, False),
+            ("eugr", {"rebuild": True}, False),
+            ("", {"rebuild": False}, False),
+            ("", {}, False),
+            ("", None, False),
         ],
     )
-    def test_derivation(self, builder_config, expected):
-        # Mirrors the expression in distribute_from_config; kept as a unit so a
-        # change to the truthiness rule (e.g. a None-vs-absent distinction) is
-        # caught without standing up the whole distribution path.
-        force_pull = bool(builder_config.get("rebuild")) if builder_config else False
-        assert force_pull is expected
+    def test_derivation(self, builder, builder_config, expected):
+        from types import SimpleNamespace
+
+        from sparkrun.orchestration.distribution import _force_registry_pull_for_recipe
+
+        recipe = SimpleNamespace(builder=builder, builder_config=builder_config)
+        assert _force_registry_pull_for_recipe(recipe) is expected
 
     def test_cli_rebuild_flag_lands_on_builder_config(self):
         """The CLI writes the flag the distribution layer reads."""

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -485,6 +485,35 @@ def test_recipe_build_config_chain(sample_v2_recipe_data: dict[str, Any]):
     assert config.get("model") == "meta-llama/Llama-2-7b-hf"
 
 
+def test_model_revision_is_injected_only_when_pinned(sample_v2_recipe_data: dict[str, Any]):
+    """`{model_revision}` must resolve so a command: can pass the pin to the
+    engine — but only when there *is* a pin. Injecting `None` would render
+    `--revision None`, which looks like a valid argument and fails inside the
+    engine, instead of failing visibly as an unsubstituted placeholder."""
+    unpinned = Recipe.from_dict(sample_v2_recipe_data)
+    assert unpinned.model_revision is None
+    assert unpinned.build_config_chain().get("model_revision") is None
+
+    sha = "51058cd551c7e570d87bd32a4adee720edce2349"
+    pinned = Recipe.from_dict({**sample_v2_recipe_data, "model_revision": sha})
+    assert pinned.build_config_chain().get("model_revision") == sha
+
+    # Reachable from a command: template, and from another default's value.
+    pinned.command = "vllm serve {model} --revision {model_revision}"
+    assert pinned.render_command(pinned.build_config_chain()).endswith("--revision " + sha)
+
+    indirect = Recipe.from_dict({**sample_v2_recipe_data, "model_revision": sha, "defaults": {"rev": "{model_revision}"}})
+    indirect.command = "vllm serve {model} --revision {rev}"
+    assert indirect.render_command(indirect.build_config_chain()).endswith("--revision " + sha)
+
+
+def test_recipe_declared_model_revision_default_wins(sample_v2_recipe_data: dict[str, Any]):
+    """`setdefault`, matching `model` — a recipe that declares the key itself
+    keeps its own value."""
+    recipe = Recipe.from_dict({**sample_v2_recipe_data, "model_revision": "aaa", "defaults": {"model_revision": "bbb"}})
+    assert recipe.build_config_chain().get("model_revision") == "bbb"
+
+
 def test_recipe_render_command(sample_v2_recipe_data: dict[str, Any]):
     """Render a recipe command template and verify placeholders are substituted.
 

--- a/tests/test_recipe_fingerprint.py
+++ b/tests/test_recipe_fingerprint.py
@@ -180,6 +180,47 @@ def test_metadata_only_recipes_share_a_fingerprint():
     assert derive_recipe_fingerprint(a) == derive_recipe_fingerprint(b)
 
 
+def test_registry_provenance_does_not_change_fingerprint():
+    """A registry reference and its local YAML identify the same workload."""
+    recipe = _recipe()
+    local = derive_recipe_fingerprint(recipe)
+
+    recipe.source_registry = "example"
+    recipe.source_registry_url = "https://github.com/example/recipes.git"
+    recipe._qualified_name_override = "@example/qwen"
+
+    assert derive_recipe_fingerprint(recipe) == local
+
+
+def test_implicit_model_revision_template_variable_preserves_fingerprint():
+    """Template-variable injection must not invalidate published identities.
+
+    ``model_revision`` was historically hashed as a top-level attribute.  It
+    later became an implicit config-chain entry so command templates could use
+    ``{model_revision}``; that second representation must not move the digest.
+    """
+    recipe = _recipe(model_revision="abc123")
+    assert recipe.build_config_chain().get("model_revision") == "abc123"
+
+    class LegacyRecipe(Recipe):
+        def build_config_chain(self, overrides=None, user_config=None):
+            chain = super().build_config_chain(overrides, user_config)
+            return {key: chain.get(key) for key in chain.keys() if key != "model_revision"}
+
+    legacy = LegacyRecipe(_recipe(model_revision="abc123")._raw)
+
+    assert derive_recipe_fingerprint(recipe) == derive_recipe_fingerprint(legacy)
+
+
+def test_explicit_model_revision_override_still_changes_fingerprint():
+    recipe = _recipe(model_revision="abc123")
+
+    assert derive_recipe_fingerprint(recipe) != derive_recipe_fingerprint(
+        recipe,
+        {"model_revision": "def456"},
+    )
+
+
 # ---------------------------------------------------------------------------
 # Host-dependence: why the digest must be derived before the launch
 # ---------------------------------------------------------------------------

--- a/tests/test_recipe_mount_trust.py
+++ b/tests/test_recipe_mount_trust.py
@@ -76,8 +76,42 @@ def test_untrusted_recipe_with_privileged_executor_keys_is_rejected(exec_cfg):
 
 def test_untrusted_recipe_with_benign_executor_keys_is_allowed():
     """Innocuous resource knobs are not gated — they can't break isolation."""
-    recipe = _recipe(executor_config={"shm_size": "16gb", "ipc": "host", "memory_limit": "64g"})
+    recipe = _recipe(executor_config={"shm_size": "16gb", "network": "host", "memory_limit": "64g"})
     _enforce_recipe_mount_trust(recipe, trusted=False)  # must not raise
+
+
+@pytest.mark.parametrize("mode", ["private", "shareable", "none", "", "SHAREABLE"])
+def test_untrusted_recipe_may_narrow_its_ipc_namespace(mode):
+    """Any mode giving the container its *own* IPC namespace is free."""
+    _enforce_recipe_mount_trust(_recipe(executor_config={"ipc": mode}), trusted=False)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "host",  # the host's /dev/shm: every other tenant's shm + semaphores
+        "HOST",  # normalization must not be a bypass
+        " host ",
+        "container:sparkrun_abc123_def456_node_0",  # another workload's namespace
+        True,  # a YAML bool, coerced by from_chain — must fail closed
+        "shareable-ish",  # unrecognised: allowlist, not a denylist of "host"
+    ],
+)
+def test_untrusted_recipe_cannot_leave_its_ipc_namespace(mode):
+    """``ipc`` is gated on value: reaching outside the container is an escalation.
+
+    Container names are derivable from a cluster_id, so ``container:<name>`` is
+    a targeted lateral read of another tenant's shared memory, not a lucky one.
+    """
+    recipe = _recipe(executor_config={"ipc": mode})
+    with pytest.raises(RecipeError, match="ipc"):
+        _enforce_recipe_mount_trust(recipe, trusted=False)
+
+
+def test_trusted_recipe_may_request_host_ipc():
+    # The legitimate use (cross-container shared memory on one host) is still
+    # reachable — with --trust, like every other isolation escape hatch.
+    _enforce_recipe_mount_trust(_recipe(executor_config={"ipc": "host"}), trusted=True)
 
 
 def test_untrusted_recipe_with_entrypoint_is_allowed():

--- a/tests/test_recipe_validation.py
+++ b/tests/test_recipe_validation.py
@@ -1264,6 +1264,67 @@ def test_rendezvous_flag_list_is_per_runtime(v):
     assert check_hardcoded_rendezvous_flags(world, vllm) == []
 
 
+# --------------------------------------------------------------------------
+# Pinned model_revision never passed to the engine
+# --------------------------------------------------------------------------
+
+
+_REV = "51058cd551c7e570d87bd32a4adee720edce2349"
+
+
+def test_pinned_model_revision_not_passed_to_engine_is_reported(v):
+    """The pin reaches distribution and stops there. sparkrun downloads by raw
+    SHA (no ``refs/`` written) and the container runs HF_HUB_OFFLINE=1, so the
+    engine resolves ``main``, finds no ref, and dies *after* the whole model has
+    synced."""
+    recipe = _recipe(model_revision=_REV, command="vllm serve {model} --port 8000").resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "unpinned-model-revision")
+    assert found.severity == WARNING
+    assert _REV in found.summary
+    assert "--revision" in found.summary
+    assert "--revision {model_revision}" in found.fix
+
+
+def test_model_revision_passed_in_command_is_not_reported(v):
+    recipe = _recipe(model_revision=_REV, command="vllm serve {model} --revision {model_revision}").resolve()
+    assert "unpinned-model-revision" not in _codes(validate_recipe(recipe, v=v))
+    equals = _recipe(model_revision=_REV, command="vllm serve {model} --revision=%s" % _REV).resolve()
+    assert "unpinned-model-revision" not in _codes(validate_recipe(equals, v=v))
+
+
+def test_unpinned_recipe_is_not_reported(v):
+    recipe = _recipe(command="vllm serve {model}").resolve()
+    assert "unpinned-model-revision" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_model_revision_check_is_per_runtime(v):
+    """A runtime that never hands a repo id to an engine that resolves it
+    declares nothing, which disables the check — the same fail-open default an
+    out-of-tree runtime built against an older base class gets."""
+    from sparkrun.core.bootstrap import get_runtime
+    from sparkrun.core.validation import check_unpinned_model_revision
+
+    vllm = get_runtime("vllm-distributed", v)
+    llama = get_runtime("llama-cpp", v)
+
+    assert llama.model_revision_flags() == ()
+    bare = _recipe(model_revision=_REV, command="serve {model}")
+    assert check_unpinned_model_revision(bare, llama) == []
+    assert check_unpinned_model_revision(bare, vllm) != []
+    assert get_runtime("sglang", v).model_revision_flags() == ("--revision",)
+
+
+def test_pre_placed_weights_skip_the_model_revision_check(v):
+    """An absolute ``model:`` path is served from a directory — there is no repo
+    id for the engine to resolve, so there is nothing to pin."""
+    from sparkrun.core.bootstrap import get_runtime
+    from sparkrun.core.validation import check_unpinned_model_revision
+
+    vllm = get_runtime("vllm-distributed", v)
+    local = _recipe(model="/mnt/shared/weights", model_revision=_REV, command="vllm serve {model}")
+    assert check_unpinned_model_revision(local, vllm) == []
+
+
 def test_runtime_declaring_no_rendezvous_flags_disables_the_check(v):
     """`vllm-ray` rendezvouses through Ray and `trtllm` through `mpirun -H`, so
     neither has a serve flag to protect. The empty base default is also what an

--- a/tests/test_recipe_validation.py
+++ b/tests/test_recipe_validation.py
@@ -31,8 +31,10 @@ def v():
 
 
 def _recipe(**overrides) -> Recipe:
+    # No ``name:``. It is the v1 spelling and is ignored on load (the recipe's
+    # name comes from the filename), so carrying one here would put a
+    # `deprecated-recipe-name` finding on every recipe every other test builds.
     data = {
-        "name": "test-recipe",
         "model": "Qwen/Qwen3-1.7B",
         "runtime": "vllm-distributed",
         "container": "vllm/vllm-openai:latest",
@@ -1418,3 +1420,62 @@ def test_internal_key_holding_a_script_is_reported_by_both_checks(v):
     codes = _codes(validate_recipe(recipe, v=v))
     assert "internal-config-key" in codes
     assert "inline-script" in codes
+
+
+# --------------------------------------------------------------------------
+# Deprecated top-level `name:`
+# --------------------------------------------------------------------------
+
+
+def test_declared_name_is_reported_as_a_deprecation(v):
+    """`name:` is the v1 spelling and is already ignored — `Recipe.__init__`
+    assigns the filename stem unconditionally (the `data.get("name", ...)`
+    beside it is commented out)."""
+    recipe = _recipe(name="Gemma 4-26B").resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "deprecated-recipe-name")
+    assert found.severity == WARNING
+    assert found.deprecation is True
+    assert "'Gemma 4-26B'" in found.summary
+
+
+def test_declared_name_finding_reads_raw_not_the_parsed_attribute(v):
+    """The parsed `name` is *never* the declared value, so a check testing it
+    would report every recipe or none. The same trap as `mode:`."""
+    recipe = _recipe(name="Gemma 4-26B")
+    assert recipe.name != "Gemma 4-26B"  # derived, not declared
+    assert "deprecated-recipe-name" in _codes(validate_recipe(recipe, v=v))
+
+
+def test_no_declared_name_is_not_reported(v):
+    assert "deprecated-recipe-name" not in _codes(validate_recipe(_recipe().resolve(), v=v))
+
+
+def test_declared_name_is_not_reported_for_v1_recipes(v):
+    """Every v1 recipe in the cached corpus declares one, and they already
+    carry `deprecated-recipe-format`, whose migration subsumes this — the same
+    gating the v1 brace escape uses."""
+    recipe = _recipe(recipe_version="1", name="Diffusion-Gemma-BF16", command="vllm serve {model}").resolve()
+    codes = _codes(validate_recipe(recipe, v=v))
+    assert "deprecated-recipe-format" in codes
+    assert "deprecated-recipe-name" not in codes
+
+
+def test_declared_name_survives_a_recipe_without_raw(v):
+    """`__setstate__` does not restore `_raw`, so a recipe revived from the
+    registry cache has no attribute at all."""
+    recipe = _recipe(name="X").resolve()
+    del recipe._raw
+    assert "deprecated-recipe-name" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_declared_name_is_collapsed_at_launch(v):
+    """A deprecation, so `summarize_deprecations` replaces it with one pointer
+    line rather than a paragraph between the runner and their logs."""
+    from sparkrun.core.validation import summarize_deprecations
+
+    issues = validate_recipe(_recipe(name="X").resolve(), v=v)
+    collapsed = summarize_deprecations(issues, "my-recipe")
+    assert "deprecated-recipe-name" not in {i.code for i in collapsed}
+    summary = next(i for i in collapsed if i.code == "deprecated-feature")
+    assert "deprecated-recipe-name" in summary.summary
+    assert "recipe validate my-recipe" in summary.fix

--- a/tests/test_recipe_validation.py
+++ b/tests/test_recipe_validation.py
@@ -1139,3 +1139,282 @@ def test_mods_alone_does_not_infer_a_builder(v):
     recipe = _recipe(runtime="vllm", mods=["mods/some-patch"]).resolve()
     assert recipe.builder == ""
     assert "implicit-builder" not in _codes(validate_recipe(recipe, v=v))
+
+
+# --------------------------------------------------------------------------
+# Restated substitutions — values sparkrun would have supplied anyway
+# --------------------------------------------------------------------------
+
+
+def test_literal_model_id_as_positional_serve_arg_is_reported(v):
+    """The dominant shape: 39 of the 118 cached registry recipes with a
+    `command:` write `vllm serve <literal id>` where `{model}` belongs."""
+    recipe = _recipe(command="vllm serve Qwen/Qwen3-1.7B --port 8000").resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "restated-model-arg")
+    assert found.severity == SUGGESTION
+    assert "Qwen/Qwen3-1.7B" in found.summary
+    assert "{model}" in found.fix
+
+
+def test_literal_model_id_as_flag_value_is_reported(v):
+    recipe = _recipe(runtime="sglang", command="sglang serve --model-path Qwen/Qwen3-1.7B").resolve()
+    assert "restated-model-arg" in _codes(validate_recipe(recipe, v=v))
+
+
+def test_model_placeholder_is_not_reported(v):
+    """The working spelling. A finding that fires here would fire on the
+    two-thirds of the corpus that is doing the right thing."""
+    recipe = _recipe(command="vllm serve {model} --port {port}", defaults={"port": 8000}).resolve()
+    assert "restated-model-arg" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_model_id_embedded_in_another_argument_is_not_reported(v):
+    """Whole-token equality, never substring: measured across the cached
+    registries the id appears *only* as the model argument, so substring
+    matching would buy nothing and claim this."""
+    recipe = _recipe(command="vllm serve {model} --served-model-name Qwen/Qwen3-1.7B-chat").resolve()
+    assert "restated-model-arg" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_absolute_model_path_is_not_reported(v):
+    """`model:` is already the on-disk path, so `{model}` renders the same
+    string and none of the three rewrite mechanisms applies."""
+    recipe = _recipe(model="/mnt/weights/qwen3", command="vllm serve /mnt/weights/qwen3").resolve()
+    assert "restated-model-arg" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_managed_container_path_in_command_is_reported(v):
+    recipe = _recipe(command="vllm serve /cache/huggingface/hub/models--Qwen--Qwen3-1.7B/snapshots/abc").resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "restated-managed-path")
+    assert found.severity == SUGGESTION
+    assert "/cache/huggingface" in found.summary
+    assert "models--Qwen--Qwen3-1.7B" in found.summary
+
+
+def test_managed_container_path_in_hook_is_reported(v):
+    """The one instance in the cached corpus is a `pre_exec`, not a `command:`
+    — and it searches a cache root sparkrun never populates."""
+    recipe = _recipe(
+        command="vllm serve {model}",
+        pre_exec=['cp "$(find /root/.cache/huggingface/ -name parser.py | head -1)" /tmp/p.py'],
+    ).resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "restated-managed-path")
+    assert found.summary.startswith("pre_exec:")
+
+
+def test_ordinary_paths_are_not_managed_paths(v):
+    recipe = _recipe(command="vllm serve {model} --chat-template /opt/templates/chat.jinja").resolve()
+    assert "restated-managed-path" not in _codes(validate_recipe(recipe, v=v))
+
+
+# --------------------------------------------------------------------------
+# Sparkrun-owned config keys
+# --------------------------------------------------------------------------
+
+
+def test_internal_config_key_in_defaults_is_reported(v):
+    """Nothing reported this before: `launcher._is_internal_config_key`
+    excludes `_`-prefixed keys from the unmapped-key report, which left a
+    recipe *declaring* one with no diagnostic at all."""
+    recipe = _recipe(
+        model="unsloth/Qwen3-1.7B-GGUF:Q4_K_M",
+        runtime="llama-cpp",
+        defaults={"_gguf_model_path": "/cache/huggingface/hub/x.gguf"},
+    ).resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "internal-config-key")
+    assert found.severity == WARNING
+    assert "_gguf_model_path" in found.summary
+
+
+def test_ordinary_defaults_keys_are_not_internal(v):
+    recipe = _recipe(defaults={"port": 8000, "max_model_len": 4096}).resolve()
+    assert "internal-config-key" not in _codes(validate_recipe(recipe, v=v))
+
+
+# --------------------------------------------------------------------------
+# Per-launch coordination flags
+# --------------------------------------------------------------------------
+
+
+def test_hardcoded_rendezvous_flags_are_reported(v):
+    recipe = _recipe(command="vllm serve {model} --nnodes 2 --node-rank 0 --master-addr 10.0.0.5").resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "hardcoded-rendezvous-flag")
+    assert found.severity == WARNING
+    assert "'--nnodes'" in found.summary and "'--master-addr'" in found.summary
+
+
+def test_rendezvous_flag_list_is_per_runtime(v):
+    """Atlas spells the world `--rank`/`--world-size`; vLLM's `--nnodes` is not
+    its vocabulary and must not be reported against it. The lists are declared
+    per runtime precisely so they can drift apart."""
+    from sparkrun.core.bootstrap import get_runtime
+    from sparkrun.core.validation import check_hardcoded_rendezvous_flags
+
+    atlas = get_runtime("atlas", v)
+    vllm = get_runtime("vllm-distributed", v)
+
+    nnodes = _recipe(command="spark serve {model} --nnodes 2")
+    assert check_hardcoded_rendezvous_flags(nnodes, atlas) == []
+    assert check_hardcoded_rendezvous_flags(nnodes, vllm) != []
+
+    world = _recipe(command="spark serve {model} --world-size 2")
+    assert check_hardcoded_rendezvous_flags(world, atlas) != []
+    assert check_hardcoded_rendezvous_flags(world, vllm) == []
+
+
+def test_runtime_declaring_no_rendezvous_flags_disables_the_check(v):
+    """`vllm-ray` rendezvouses through Ray and `trtllm` through `mpirun -H`, so
+    neither has a serve flag to protect. The empty base default is also what an
+    out-of-tree runtime built against an older base class gets."""
+    from sparkrun.core.bootstrap import get_runtime
+    from sparkrun.core.validation import check_hardcoded_rendezvous_flags
+
+    for name in ("vllm-ray", "trtllm"):
+        runtime = get_runtime(name, v)
+        assert runtime.managed_rendezvous_flags() == ()
+        recipe = _recipe(runtime=name, command="vllm serve {model} --nnodes 2")
+        assert check_hardcoded_rendezvous_flags(recipe, runtime) == []
+
+
+def test_data_parallel_size_is_not_a_rendezvous_flag(v):
+    """The one flag in vLLM's block injected only when the template did not
+    supply it — writing it is a supported choice, not a collision."""
+    recipe = _recipe(command="vllm serve {model} --data-parallel-size 2").resolve()
+    assert "hardcoded-rendezvous-flag" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_clean_recipe_produces_none_of_the_new_findings(v):
+    """The corpus posture: all 160 cached registry recipes produce zero of the
+    two new warnings, and a recipe using placeholders throughout produces none
+    of the four."""
+    recipe = _recipe(
+        command="vllm serve {model} --port {port} --tensor-parallel-size {tensor_parallel}",
+        defaults={"port": 8000, "tensor_parallel": 2},
+    ).resolve()
+    codes = _codes(validate_recipe(recipe, v=v))
+    assert not codes & {
+        "restated-model-arg",
+        "restated-managed-path",
+        "internal-config-key",
+        "hardcoded-rendezvous-flag",
+    }
+
+
+def test_managed_container_path_in_a_defaults_value_is_reported(v):
+    """A serve flag can name a path sparkrun owns just as a command can."""
+    recipe = _recipe(
+        command="vllm serve {model} --chat-template {chat_template}",
+        defaults={"chat_template": "/cache/huggingface/hub/models--Qwen--Qwen3-1.7B/snapshots/a/chat.jinja"},
+    ).resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "restated-managed-path")
+    assert found.summary.startswith("defaults.chat_template:")
+
+
+def test_internal_key_holding_a_managed_path_is_reported_once(v):
+    """`internal-config-key` already owns that line and says strictly more;
+    a second finding on the same assignment is the noise this module avoids."""
+    recipe = _recipe(defaults={"_gguf_model_path": "/cache/huggingface/hub/x.gguf"}).resolve()
+    codes = [i.code for i in validate_recipe(recipe, v=v)]
+    assert codes.count("internal-config-key") == 1
+    assert "restated-managed-path" not in codes
+
+
+# --------------------------------------------------------------------------
+# Inline scripting and patching
+# --------------------------------------------------------------------------
+
+
+def test_heredoc_program_in_command_is_reported(v):
+    """The canonical shape: an `@spark-arena` recipe whose `command:` carries a
+    ~280-line Python program that rewrites vLLM's source before the serve
+    line."""
+    recipe = _recipe(
+        command="set -euo pipefail\npython3 - <<'PY'\nprint('patching')\nPY\nexec vllm serve {model}",
+    ).resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "inline-script")
+    assert found.severity == SUGGESTION
+    assert found.summary.startswith("command:")
+    assert "heredoc" in found.summary
+    assert "`mods:`" in found.fix
+
+
+def test_in_place_patching_in_pre_exec_is_reported(v):
+    recipe = _recipe(
+        command="vllm serve {model}",
+        pre_exec=["sed -i 's/foo/bar/' /usr/lib/python3/site-packages/vllm/config.py"],
+    ).resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "inline-script")
+    assert found.summary.startswith("pre_exec:")
+
+
+def test_launch_time_package_install_is_reported(v):
+    """The only instance in the cached corpus (two recipes), and the one case
+    where the image is the better fix than a mod — so the advice names both."""
+    recipe = _recipe(command="vllm serve {model}", pre_exec=["python3 -m pip install cohere_melody"]).resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "inline-script")
+    assert "package install" in found.summary
+    assert "container image" in found.fix
+
+
+def test_ordinary_shell_in_a_command_is_not_an_inline_script(v):
+    """Shape is deliberately not a signal. A serve command wrapped in a couple
+    of shell lines is the common idiom and must stay silent — a line-count
+    threshold would have reported the recipes with the most flags."""
+    recipe = _recipe(
+        command="set -euo pipefail\nexport VLLM_USE_V1=1\nexec vllm serve {model} --port {port}",
+        defaults={"port": 8000},
+    ).resolve()
+    assert "inline-script" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_a_recipe_using_mods_properly_is_not_reported(v):
+    """The shape the finding recommends. `mods:` resolution happens inside
+    `launch_inference`, long after validation, so the entries seen here are the
+    author's own and never sparkrun's injected mod-runner."""
+    recipe = _recipe(command="vllm serve {model}", mods=["mods/glm53-sm121-patch"]).resolve()
+    assert "inline-script" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_sed_without_in_place_is_not_reported(v):
+    """`sed -n`/`sed -e` filtering a stream edits nothing; only `-i` does."""
+    recipe = _recipe(command="vllm serve {model} --port $(sed -n 1p /etc/portfile)").resolve()
+    assert "inline-script" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_inline_script_in_a_defaults_value_is_reported(v):
+    """A default reaches the command through its placeholder, so a program can
+    be written there too — one remove further from where it runs."""
+    recipe = _recipe(
+        command="vllm serve {model} && {setup}",
+        defaults={"setup": "python3 - <<'PY'\nimport vllm\nPY"},
+    ).resolve()
+    found = next(i for i in validate_recipe(recipe, v=v) if i.code == "inline-script")
+    assert found.summary.startswith("defaults.setup:")
+
+
+def test_site_packages_path_in_a_defaults_value_is_not_a_script(v):
+    """The one signal that names a *location* rather than a verb. In a command
+    it is nearly always the target of a write; in a serve-flag value it is as
+    likely to be a plain path, and calling that an inline script is wrong."""
+    recipe = _recipe(
+        command="vllm serve {model} --chat-template {chat_template}",
+        defaults={"chat_template": "/usr/lib/python3.12/site-packages/vllm/templates/tool.jinja"},
+    ).resolve()
+    assert "inline-script" not in _codes(validate_recipe(recipe, v=v))
+
+
+def test_site_packages_write_in_a_command_is_still_a_script(v):
+    """Narrowed for `defaults:` only — the command scan keeps the full set."""
+    recipe = _recipe(command="cp /tmp/fix.py /usr/lib/python3/site-packages/vllm/x.py && vllm serve {model}").resolve()
+    assert "inline-script" in _codes(validate_recipe(recipe, v=v))
+
+
+def test_internal_key_holding_a_script_is_reported_by_both_checks(v):
+    """Unlike the managed-path scan, the script scan does *not* skip
+    `_`-prefixed defaults: "you declared a key sparkrun owns" and "you put a
+    program in it" are different problems, and the first message covers neither
+    the second's diagnosis nor its fix."""
+    recipe = _recipe(defaults={"_gguf_model_path": "$(python3 -c 'print(1)')"}).resolve()
+    codes = _codes(validate_recipe(recipe, v=v))
+    assert "internal-config-key" in codes
+    assert "inline-script" in codes

--- a/tests/test_recipe_validation.py
+++ b/tests/test_recipe_validation.py
@@ -1350,12 +1350,22 @@ def test_in_place_patching_in_pre_exec_is_reported(v):
 
 
 def test_launch_time_package_install_is_reported(v):
-    """The only instance in the cached corpus (two recipes), and the one case
-    where the image is the better fix than a mod — so the advice names both."""
+    """The only instance in the cached corpus (two recipes)."""
     recipe = _recipe(command="vllm serve {model}", pre_exec=["python3 -m pip install cohere_melody"]).resolve()
     found = next(i for i in validate_recipe(recipe, v=v) if i.code == "inline-script")
     assert "package install" in found.summary
-    assert "container image" in found.fix
+
+
+def test_inline_script_offers_image_and_mod_as_peers(v):
+    """Both remedies are real and the choice is the author's — publishing an
+    image is not always practical, and a mod is not always the right home for
+    an expensive or reusable change. The advice must not steer to one."""
+    recipe = _recipe(command="python3 - <<'PY'\npass\nPY\nvllm serve {model}").resolve()
+    fix = next(i for i in validate_recipe(recipe, v=v) if i.code == "inline-script").fix
+    assert "container image" in fix and "`mods:`" in fix
+    # Named in that order, each with the condition that selects it.
+    assert fix.index("container image") < fix.index("`mods:`")
+    assert "stable or expensive" in fix and "impractical" in fix
 
 
 def test_ordinary_shell_in_a_command_is_not_an_inline_script(v):

--- a/tests/test_registry_defaults.py
+++ b/tests/test_registry_defaults.py
@@ -1,0 +1,339 @@
+"""Tests for plugin-declared default registries (``core.registry_defaults``)."""
+
+from __future__ import annotations
+
+import pytest
+
+from sparkrun.core.registry import (
+    FALLBACK_DEFAULT_REGISTRIES,
+    SUPPRESSED_REGISTRIES_KEY,
+    RegistryEntry,
+    RegistryError,
+    RegistryManager,
+)
+from sparkrun.core.registry_defaults import (
+    DeclarationTier,
+    declaring_tier,
+    iter_declared_registries,
+    register_default_registry,
+    reset_declared_registries,
+)
+
+import yaml
+
+PLUGIN_URL = "https://github.com/sparksq/sparkrun-recipes.git"
+
+
+def _entry(name: str = "coldsnap", **kw) -> RegistryEntry:
+    fields = {"name": name, "url": PLUGIN_URL, "subpath": "coldsnap-recipes"}
+    fields.update(kw)
+    return RegistryEntry(**fields)
+
+
+@pytest.fixture
+def mgr(tmp_path) -> RegistryManager:
+    return RegistryManager(config_root=tmp_path / "config", cache_root=tmp_path / "cache")
+
+
+def _read_yaml(mgr: RegistryManager) -> dict:
+    return yaml.safe_load(mgr._registries_path.read_text()) or {}
+
+
+# --------------------------------------------------------------------------
+# Registration
+# --------------------------------------------------------------------------
+
+
+def test_declaration_requires_a_non_blank_owner():
+    with pytest.raises(ValueError):
+        register_default_registry(_entry(), owner="   ")
+
+
+def test_declaration_is_idempotent_for_the_same_owner_and_entry():
+    register_default_registry(_entry(), owner="coldsnap")
+    register_default_registry(_entry(), owner="coldsnap")
+    assert len(iter_declared_registries()) == 1
+
+
+def test_a_second_owner_cannot_claim_an_existing_name():
+    register_default_registry(_entry(), owner="coldsnap")
+    with pytest.raises(RegistryError, match="already declared by plugin 'coldsnap'"):
+        register_default_registry(_entry(), owner="impostor")
+
+
+def test_the_same_owner_may_revise_its_own_declaration():
+    register_default_registry(_entry(), owner="coldsnap")
+    register_default_registry(_entry(description="revised"), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    assert declared.entry.description == "revised"
+
+
+def test_an_unsafe_name_is_rejected():
+    with pytest.raises(RegistryError):
+        register_default_registry(_entry(name="../escape"), owner="coldsnap")
+
+
+def test_an_unsafe_subpath_is_rejected():
+    with pytest.raises(RegistryError):
+        register_default_registry(_entry(subpath="../../etc"), owner="coldsnap")
+
+
+def test_a_reserved_name_from_the_wrong_org_is_rejected():
+    """`coldsnap` is reserved to sparksq; another org may not declare it."""
+    with pytest.raises(RegistryError, match="reserved"):
+        register_default_registry(
+            _entry(url="https://github.com/somebody-else/recipes.git"),
+            owner="impostor",
+        )
+
+
+def test_the_reserved_name_is_accepted_from_its_own_org():
+    register_default_registry(_entry(), owner="coldsnap")
+    assert [d.entry.name for d in iter_declared_registries()] == ["coldsnap"]
+
+
+def test_reserved_names_admit_the_urls_coldsnap_declares():
+    """Guards the §4 failure mode: a mismatch makes the plugin raise at bootstrap."""
+    from sparkrun.core.registry import EXTERNAL_RESERVED_NAMES, _get_git_org
+
+    org = _get_git_org(PLUGIN_URL)
+    assert org == "sparksq"
+    for name in ("coldsnap", "coldsnap-vanilla"):
+        assert org in EXTERNAL_RESERVED_NAMES[name]
+
+
+def test_declarations_are_ordered_deterministically():
+    register_default_registry(_entry("coldsnap-vanilla", subpath="vanilla-recipes"), owner="coldsnap")
+    register_default_registry(_entry("coldsnap"), owner="coldsnap")
+    assert [d.entry.name for d in iter_declared_registries()] == ["coldsnap", "coldsnap-vanilla"]
+
+
+# --------------------------------------------------------------------------
+# Tier / trust
+# --------------------------------------------------------------------------
+
+
+def test_in_tree_declarations_may_ship_trusted():
+    with declaring_tier(DeclarationTier.IN_TREE):
+        register_default_registry(_entry(trusted=True), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    assert declared.effective_entry().trusted is True
+
+
+def test_out_of_tree_declarations_are_forced_untrusted():
+    with declaring_tier(DeclarationTier.OUT_OF_TREE):
+        register_default_registry(_entry(trusted=True), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    assert declared.effective_entry().trusted is False
+
+
+def test_the_default_tier_is_the_unprivileged_one():
+    """A declaration made outside any loader must not acquire in-tree trust."""
+    register_default_registry(_entry(trusted=True), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    assert declared.tier is DeclarationTier.OUT_OF_TREE
+    assert declared.effective_entry().trusted is False
+
+
+def test_effective_entry_does_not_alias_the_declaration():
+    with declaring_tier(DeclarationTier.IN_TREE):
+        register_default_registry(_entry(), owner="coldsnap")
+    (declared,) = iter_declared_registries()
+    first = declared.effective_entry()
+    first.enabled = False
+    assert declared.effective_entry().enabled is True
+
+
+def test_the_loader_supplies_the_tier(monkeypatch):
+    """load_plugin_module wraps registration; the plugin never states its tier."""
+    import types
+
+    from sparkrun.core.external_plugins import load_plugin_module
+
+    module = types.ModuleType("fake_in_tree_plugin")
+    module.register = lambda v: register_default_registry(_entry(trusted=True), owner="coldsnap")
+    monkeypatch.setattr("sparkrun.core.external_plugins._plugin_base_types", lambda: [])
+
+    load_plugin_module(module, None, tier=DeclarationTier.IN_TREE)
+    (declared,) = iter_declared_registries()
+    assert declared.tier is DeclarationTier.IN_TREE
+    assert declared.effective_entry().trusted is True
+
+
+def test_the_tier_does_not_leak_past_a_load(monkeypatch):
+    import types
+
+    from sparkrun.core.external_plugins import load_plugin_module
+
+    module = types.ModuleType("fake_plugin")
+    module.register = lambda v: None
+    monkeypatch.setattr("sparkrun.core.external_plugins._plugin_base_types", lambda: [])
+    load_plugin_module(module, None, tier=DeclarationTier.IN_TREE)
+
+    register_default_registry(_entry(trusted=True), owner="later")
+    (declared,) = iter_declared_registries()
+    assert declared.tier is DeclarationTier.OUT_OF_TREE
+
+
+# --------------------------------------------------------------------------
+# Overlay
+# --------------------------------------------------------------------------
+
+
+def test_the_overlay_appears_on_a_fresh_install(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    assert "coldsnap" in {r.name for r in mgr.list_registries()}
+
+
+def _materialize_config(mgr: RegistryManager) -> None:
+    """Force registries.yaml into existence.
+
+    ``_default_registries`` only persists when manifest discovery found
+    something, and the hermetic suite empties ``BOOTSTRAP_REGISTRY_URLS`` — so a
+    plain ``list_registries()`` leaves no file. Any mutation writes one.
+    """
+    mgr.add_registry(RegistryEntry(name="seed", url="https://github.com/me/seed.git", subpath="r"))
+    assert mgr._registries_path.exists()
+
+
+def test_the_overlay_appears_on_an_existing_install(mgr):
+    _materialize_config(mgr)
+
+    register_default_registry(_entry(), owner="coldsnap")
+    entry = next(r for r in mgr.list_registries() if r.name == "coldsnap")
+    assert entry.declared_by == "coldsnap"
+
+
+def test_the_overlay_is_never_persisted(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.list_registries()
+    mgr.disable_registry("official")  # force a save of an unrelated entry
+
+    names = {r["name"] for r in _read_yaml(mgr)["registries"]}
+    assert "coldsnap" not in names
+
+
+def test_withdrawing_a_declaration_removes_the_entry(mgr):
+    _materialize_config(mgr)
+    register_default_registry(_entry(), owner="coldsnap")
+    assert "coldsnap" in {r.name for r in mgr.list_registries()}
+
+    reset_declared_registries()
+    assert "coldsnap" not in {r.name for r in mgr.list_registries()}
+    assert "coldsnap" not in {r["name"] for r in _read_yaml(mgr)["registries"]}
+
+
+def test_a_file_entry_of_the_same_name_wins(mgr):
+    mgr.add_registry(_entry(url="https://github.com/sparksq/sparkrun-recipes.git", subpath="mine"))
+    register_default_registry(_entry(subpath="coldsnap-recipes"), owner="coldsnap")
+
+    entry = next(r for r in mgr.list_registries() if r.name == "coldsnap")
+    assert entry.subpath == "mine"
+    assert entry.declared_by == ""
+
+
+def test_a_declaration_cannot_shadow_a_shipped_default(mgr, caplog):
+    shipped = FALLBACK_DEFAULT_REGISTRIES[0]
+    register_default_registry(
+        RegistryEntry(name=shipped.name, url="https://github.com/scitrera/other.git", subpath="r"),
+        owner="impostor",
+    )
+    with caplog.at_level("WARNING"):
+        entries = mgr.list_registries()
+
+    entry = next(r for r in entries if r.name == shipped.name)
+    assert entry.declared_by == ""
+    assert entry.url == shipped.url
+    assert "shipped default" in caplog.text
+
+
+# --------------------------------------------------------------------------
+# Materialize on mutation / tombstones
+# --------------------------------------------------------------------------
+
+
+def test_disable_materializes_the_entry(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.disable_registry("coldsnap")
+
+    saved = {r["name"]: r for r in _read_yaml(mgr)["registries"]}
+    assert saved["coldsnap"]["enabled"] is False
+    assert mgr.get_registry("coldsnap").declared_by == ""
+
+
+def test_a_materialized_entry_survives_the_declaration_being_withdrawn(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.disable_registry("coldsnap")
+    reset_declared_registries()
+
+    entry = mgr.get_registry("coldsnap")
+    assert entry.enabled is False
+    assert entry.declared_by == ""
+
+
+def test_trust_materializes_and_sticks(mgr):
+    with declaring_tier(DeclarationTier.OUT_OF_TREE):
+        register_default_registry(_entry(trusted=True), owner="coldsnap")
+    assert mgr.get_registry("coldsnap").trusted is False  # forced untrusted by tier
+
+    mgr.trust_registry("coldsnap")
+    assert mgr.get_registry("coldsnap").trusted is True
+    assert {r["name"]: r for r in _read_yaml(mgr)["registries"]}["coldsnap"]["trusted"] is True
+
+
+def test_remove_tombstones_a_declared_registry(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.remove_registry("coldsnap")
+
+    assert _read_yaml(mgr)[SUPPRESSED_REGISTRIES_KEY] == ["coldsnap"]
+    assert "coldsnap" not in {r.name for r in mgr.list_registries()}
+
+
+def test_a_tombstone_survives_a_reload_with_the_declaration_present(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.remove_registry("coldsnap")
+
+    fresh = RegistryManager(config_root=mgr.config_root, cache_root=mgr.cache_root)
+    assert "coldsnap" not in {r.name for r in fresh.list_registries()}
+
+
+def test_re_adding_clears_the_tombstone(mgr):
+    register_default_registry(_entry(), owner="coldsnap")
+    mgr.remove_registry("coldsnap")
+    mgr.add_registry(_entry(subpath="mine"))
+
+    assert SUPPRESSED_REGISTRIES_KEY not in _read_yaml(mgr)
+    assert mgr.get_registry("coldsnap").subpath == "mine"
+
+
+def test_removing_an_ordinary_registry_writes_no_tombstone(mgr):
+    mgr.add_registry(RegistryEntry(name="mine", url="https://github.com/me/r.git", subpath="r"))
+    mgr.remove_registry("mine")
+
+    assert SUPPRESSED_REGISTRIES_KEY not in _read_yaml(mgr)
+
+
+def test_removing_an_absent_registry_still_raises(mgr):
+    with pytest.raises(RegistryError, match="not found"):
+        mgr.remove_registry("nope")
+
+
+# --------------------------------------------------------------------------
+# Telemetry
+# --------------------------------------------------------------------------
+
+
+def test_a_declared_registry_is_not_counted_as_third_party():
+    from sparkrun.telemetry.util import registry_summary
+
+    declared = RegistryEntry(name="coldsnap", url=PLUGIN_URL, subpath="r", declared_by="coldsnap")
+    user_added = RegistryEntry(name="mine", url="https://github.com/me/r.git", subpath="r")
+
+    summary = registry_summary([declared, user_added])
+    assert summary["plugin_registry_count"] == 1
+    assert summary["non_default_registry_count"] == 1  # only the user's own
+    assert summary["has_non_default_registries"] is True
+
+    only_declared = registry_summary([declared])
+    assert only_declared["has_non_default_registries"] is False
+    assert only_declared["plugin_registry_count"] == 1

--- a/tests/test_run_timings_readiness.py
+++ b/tests/test_run_timings_readiness.py
@@ -41,6 +41,23 @@ from sparkrun.core.launcher import ReadinessWatcher, ServeReadiness, wait_for_en
 from sparkrun.core.timing import Timeline
 from sparkrun.orchestration.health import wait_for_healthy, wait_for_port
 
+
+@pytest.mark.parametrize(
+    ("verbosity", "expected"),
+    [(0, 2), (1, 3), (2, 4), (3, None), (4, None), (-1, 2)],
+)
+def test_run_timing_tree_depth_tracks_global_verbosity(verbosity, expected):
+    from sparkrun.cli._run import _timing_tree_depth
+
+    class Context:
+        obj = {"verbose": verbosity}
+
+        def find_root(self):
+            return self
+
+    assert _timing_tree_depth(Context()) == expected
+
+
 # ---------------------------------------------------------------------------
 # Cancellation in the underlying waiters
 # ---------------------------------------------------------------------------

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -10,6 +10,8 @@ See ``.slop/runtime-cache-design.md``.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from sparkrun.core.recipe import Recipe
@@ -365,6 +367,23 @@ def test_explicit_dir_setting_wins_over_the_probed_root():
 
 def test_root_defaults_under_the_sparkrun_cache_dir():
     assert resolve_runtime_cache_root(RuntimeCacheSettings(), "/home/u/.cache/sparkrun") == "/home/u/.cache/sparkrun/runtime-cache"
+
+
+def test_effective_runtime_cache_dir_prefers_cluster_sparkrun_root():
+    from sparkrun.core.launcher import resolve_effective_runtime_cache_dir
+
+    cluster = SimpleNamespace(sparkrun_cache_dir="/mnt/local/sparkrun")
+    config = SimpleNamespace(cache_dir="/control/cache")
+    assert (
+        resolve_effective_runtime_cache_dir(
+            ["host1"],
+            {},
+            config,
+            dry_run=True,
+            cluster=cluster,
+        )
+        == "/mnt/local/sparkrun"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_setup_check.py
+++ b/tests/test_setup_check.py
@@ -367,3 +367,86 @@ def test_check_json_output(runner, v, patched_cluster_mgr):
     assert payload["cluster"] == "mylab"
     assert payload["results"]["10.0.0.1"]["reachable"] is True
     assert payload["critical_gaps"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Host IPC vs systemd RemoveIPC (issue #285)
+# ---------------------------------------------------------------------------
+
+# A host whose logind will reap a regular user's IPC once their session ends.
+_FACTS_REAPER = dict(
+    _FACTS_ALL_GOOD,
+    CHECK_UID="1000",
+    CHECK_LOGIND_REMOVE_IPC="yes",
+    CHECK_LOGIND_LINGER="0",
+)
+
+_HOST = "10.0.0.1"
+
+
+def _ipc_ctx(exposure: str | None = "host") -> CheckContext:
+    return CheckContext(
+        cluster_name="mylab",
+        multi_host=False,
+        ipc_exposure={_HOST: exposure} if exposure is not None else {},
+    )
+
+
+def _keys(items):
+    return [i.key for i in items]
+
+
+def test_host_ipc_omitted_when_launch_does_not_use_host_namespace():
+    # The default (`shareable`) is immune, so there is no gap to report --
+    # reporting one on every host is how a check teaches people to skim.
+    items = evaluate_host(_state(_FACTS_REAPER), _ipc_ctx("shareable"))
+    assert "host_ipc" not in _keys(items)
+
+
+def test_host_ipc_omitted_when_executor_could_not_be_resolved():
+    items = evaluate_host(_state(_FACTS_REAPER), _ipc_ctx(None))
+    assert "host_ipc" not in _keys(items)
+
+
+def test_host_ipc_warns_on_reaping_host():
+    items = evaluate_host(_state(_FACTS_REAPER), _ipc_ctx())
+    item = next(i for i in items if i.key == "host_ipc")
+    assert item.status == WARN
+    assert "RemoveIPC=yes" in item.detail
+    assert "enable-linger" in item.guidance
+
+
+def test_host_ipc_ok_when_lingering_enabled():
+    facts = dict(_FACTS_REAPER, CHECK_LOGIND_LINGER="1")
+    items = evaluate_host(_state(facts), _ipc_ctx())
+    assert next(i for i in items if i.key == "host_ipc").status == OK
+
+
+def test_host_ipc_ok_when_remove_ipc_disabled():
+    facts = dict(_FACTS_REAPER, CHECK_LOGIND_REMOVE_IPC="no")
+    items = evaluate_host(_state(facts), _ipc_ctx())
+    assert next(i for i in items if i.key == "host_ipc").status == OK
+
+
+def test_host_ipc_omitted_for_system_uid():
+    # logind never reaps IPC for root / system users, which is why running the
+    # container as root masks the failure.
+    facts = dict(_FACTS_REAPER, CHECK_UID="0")
+    assert "host_ipc" not in _keys(evaluate_host(_state(facts), _ipc_ctx()))
+
+
+def test_host_ipc_unknown_remove_ipc_is_skip_not_warn():
+    facts = dict(_FACTS_REAPER, CHECK_LOGIND_REMOVE_IPC="unknown")
+    assert next(i for i in evaluate_host(_state(facts), _ipc_ctx()) if i.key == "host_ipc").status == SKIP
+
+
+def test_host_ipc_unknown_uid_is_skip_not_warn():
+    facts = dict(_FACTS_REAPER, CHECK_UID="unknown")
+    assert next(i for i in evaluate_host(_state(facts), _ipc_ctx()) if i.key == "host_ipc").status == SKIP
+
+
+def test_host_ipc_warns_when_lingering_cannot_be_confirmed():
+    facts = dict(_FACTS_REAPER, CHECK_LOGIND_LINGER="unknown")
+    item = next(i for i in evaluate_host(_state(facts), _ipc_ctx()) if i.key == "host_ipc")
+    assert item.status == WARN
+    assert "could not be confirmed" in item.detail

--- a/tests/test_sudo.py
+++ b/tests/test_sudo.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import pytest
 from unittest.mock import patch
 
-from sparkrun.orchestration.sudo import run_indirect_sudo_script, run_sudo_script_on_host
+from sparkrun.orchestration.sudo import ensure_remote_dir_ownership, run_indirect_sudo_script, run_sudo_script_on_host
 from sparkrun.orchestration.ssh import RemoteResult
+from sparkrun.transports.session import HostCommandResult
 
 
 @patch("sparkrun.orchestration.ssh._run_subprocess")
@@ -125,3 +126,25 @@ def test_local_host_accepts_none_password(mock_run):
     assert res.host == "localhost"
     assert mock_run.call_args[0][0] == ["sudo", "-n", "bash", "-s"]
     assert mock_run.call_args[1]["input"] == "apt update"
+
+
+def test_ownership_repair_can_use_manager_host_session():
+    class Session:
+        def __init__(self):
+            self.calls = []
+
+        def execute(self, host, arguments, **kwargs):
+            self.calls.append((host, arguments, kwargs))
+            return HostCommandResult(host, 0 if host == "h1" else 1)
+
+    session = Session()
+    failed = ensure_remote_dir_ownership(
+        "/home/u/.cache/sparkrun",
+        ["h1", "h2"],
+        resource_label="ColdSnap cache",
+        session=session,
+    )
+
+    assert failed == ["h2"]
+    assert [call[0] for call in session.calls] == ["h1", "h2"]
+    assert all(call[1][:2] == ["bash", "-c"] for call in session.calls)

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -328,3 +328,30 @@ def test_formatter_accepts_operation_specific_title():
 
     rendered = format_launch_timings(tl.export(), title="Capture timings")
     assert rendered.startswith("Capture timings")
+
+
+def test_formatter_limits_displayed_tree_depth():
+    from sparkrun.utils.cli_formatters import format_launch_timings
+
+    tl = Timeline()
+    with tl.span("level-1"):
+        with tl.span("level-2"):
+            with tl.span("level-3"):
+                with tl.span("level-4"):
+                    pass
+
+    rendered = format_launch_timings(tl.export(), max_depth=2)
+    assert "level-1" in rendered
+    assert "level-2" in rendered
+    assert "level-3" not in rendered
+    assert "level-4" not in rendered
+
+    unbounded = format_launch_timings(tl.export())
+    assert "level-4" in unbounded
+
+
+def test_formatter_rejects_invalid_tree_depth():
+    from sparkrun.utils.cli_formatters import format_launch_timings
+
+    with pytest.raises(ValueError, match="max_depth"):
+        format_launch_timings({"spans": [{}]}, max_depth=0)

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -355,3 +355,13 @@ def test_formatter_rejects_invalid_tree_depth():
 
     with pytest.raises(ValueError, match="max_depth"):
         format_launch_timings({"spans": [{}]}, max_depth=0)
+
+
+@pytest.mark.parametrize(
+    ("verbosity", "expected"),
+    [(0, 2), (1, 3), (2, 4), (3, None), (4, None), (-1, 2), (False, 2), (True, 3)],
+)
+def test_standard_timing_tree_depth_tracks_verbosity(verbosity, expected):
+    from sparkrun.utils.cli_formatters import timing_tree_depth_for_verbosity
+
+    assert timing_tree_depth_for_verbosity(verbosity) == expected

--- a/tests/test_vram.py
+++ b/tests/test_vram.py
@@ -142,6 +142,38 @@ class TestBytesPerElement:
     def test_strip_whitespace(self):
         assert bytes_per_element("  float16  ") == 2.0
 
+    def test_bits_per_weight_families(self):
+        """exl2/exl3 widths are per-checkpoint and fractional, so they ride in
+        the dtype string rather than in the table."""
+        assert bytes_per_element("exl3:2.05") == 2.05 / 8
+        assert bytes_per_element("exl3:4.05") == 4.05 / 8
+        assert bytes_per_element("exl2:4.25") == 4.25 / 8
+        assert bytes_per_element("EXL3:2.05") == 2.05 / 8
+
+    def test_bare_family_is_not_sizable(self):
+        """The bpw *is* the width — a family name alone carries none, and the
+        metadata validator is `bytes_per_element(...) is None`, so this is also
+        what makes a bare `exl3` in a recipe get reported."""
+        assert bytes_per_element("exl3") is None
+
+    def test_malformed_bits_per_weight_is_rejected(self):
+        assert bytes_per_element("exl3:") is None
+        assert bytes_per_element("exl3:abc") is None
+        assert bytes_per_element("foo:2.05") is None  # undeclared family
+
+    def test_bits_per_weight_is_bounded(self):
+        """A typo'd `exl3:205` must not silently size the model 100x too large."""
+        assert bytes_per_element("exl3:205") is None
+        assert bytes_per_element("exl3:0.5") is None
+
+    def test_bits_per_weight_is_weight_only(self):
+        """These are never KV-cache layouts, so the parse is deliberately absent
+        from the KV path."""
+        from sparkrun.models.kv import is_valid_kv_dtype
+
+        assert kv_bytes_per_element("exl3:2.05") is None
+        assert is_valid_kv_dtype("exl3:2.05") is False
+
 
 class TestEstimateVram:
     """Test VRAM estimation calculations."""


### PR DESCRIPTION
This pull request introduces several significant documentation updates and a small code change, focusing on clarifying and improving the handling of container IPC namespaces, shared memory settings, and plugin-declared registries. The most important changes are grouped below.

**Container IPC Namespace and Shared Memory Handling:**

* The default Docker `ipc` mode is changed from `"host"` to `"shareable"`, and the default `shm_size` is increased to `"32gb"`. Documentation is updated to explain the security and reliability implications, especially regarding systemd-logind's `RemoveIPC` behavior and why `shareable` is now preferred. [[1]](diffhunk://#diff-446ccc54369f60325d41961454f3a2efdd0e33f7c1a5bb0c7f9901ace9390611L592-R593) [[2]](diffhunk://#diff-5d212d961af70f70f74b55e25d054bf27dde13aa3f128866d046e7c7ecb8da1dL84-R85) [[3]](diffhunk://#diff-5d212d961af70f70f74b55e25d054bf27dde13aa3f128866d046e7c7ecb8da1dR185-R232)
* Security documentation now explicitly states that untrusted recipes are only allowed to set `ipc` to modes that provide a fresh namespace (`private`, `shareable`, `none`), and not to `host` or `container:<name>`, which could enable lateral access or escape the container sandbox.

**Plugin-Declared Registries:**

* Adds comprehensive documentation for plugin-declared registries, including their lifecycle, trust model, validation, and how user actions (like disable/trust/remove) interact with them. This is reflected in both user-facing and internal design documentation. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R1966-R2012) [[2]](diffhunk://#diff-a4b5186ca4937b26e09acd667292cfaf1bb5f74fa05c3657eb70e8e42787964cR143-R210)

**Catalogue and Internal Notes:**

* Expands the catalogue notes with explanations for new and existing checks, including the rationale and mechanisms for checks like `hardcoded-serve-flag`, `restated-model-arg`, and others, improving maintainability and onboarding for contributors.

**Code Change:**

* Adds a `strict` parameter (defaulting to `False`) to the `_evict_superseded_deployments` function in `src/sparkrun/api/_run.py` for future or more precise control over deployment eviction behavior.